### PR TITLE
Bring non-webkit performance up to par

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
             dist: {
                 src: [
                     'src/core.js',
+                    'src/dom.js',
                     'src/interactiveLayer.js',
                     'src/tooltip.js',
                     'src/utils.js',

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -81,7 +81,6 @@ module.exports = function(grunt) {
                     },
                     files: [
                         'bower_components/d3/d3.js',
-                        'bower_components/fastdom/index.js',
                         'src/*.js',
                         'src/models/*.js',
                         'test/mocha/*.coffee'

--- a/GruntFile.js
+++ b/GruntFile.js
@@ -81,6 +81,7 @@ module.exports = function(grunt) {
                     },
                     files: [
                         'bower_components/d3/d3.js',
+                        'bower_components/fastdom/index.js',
                         'src/*.js',
                         'src/models/*.js',
                         'test/mocha/*.coffee'

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ I fix anything I find myself, so there is a fair chance it's already fixed!
 
 ---
 
+# Optional dependencies
+
+Including [Fastdom](https://github.com/wilsonpage/fastdom) in your project can greatly increase the performance of the line chart (particularly in Firefox and Internet Explorer) by batching DOM read and write operations to avoid [layout thrashing](http://wilsonpage.co.uk/preventing-layout-thrashing/). NVD3 will take advantage of Fastdom if present.
+
+---
+
 # Contributing
 
 If one of [the existing models](https://github.com/nvd3-community/nvd3/tree/development/src/models)

--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,8 @@
   ],
   "license": "Apache License, v2.0",
   "dependencies": {
-    "d3": "~3.3.13"
+    "d3": "~3.3.13",
+    "fastdom": "~0.8.5"
   },
   "ignore": [
     "**/.*",
@@ -42,6 +43,7 @@
     "d3": "~3.3.13"
   },
   "devDependencies": {
-    "d3": "~3.3.13"
+    "d3": "~3.3.13",
+    "fastdom": "~0.8.5"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -22,8 +22,7 @@
   ],
   "license": "Apache License, v2.0",
   "dependencies": {
-    "d3": "~3.3.13",
-    "fastdom": "~0.8.5"
+    "d3": "~3.3.13"
   },
   "ignore": [
     "**/.*",
@@ -43,7 +42,6 @@
     "d3": "~3.3.13"
   },
   "devDependencies": {
-    "d3": "~3.3.13",
-    "fastdom": "~0.8.5"
+    "d3": "~3.3.13"
   }
 }

--- a/src/core.js
+++ b/src/core.js
@@ -11,6 +11,7 @@ nv.models = nv.models || {}; //stores all the possible models/components
 nv.charts = {}; //stores all the ready to use charts
 nv.graphs = []; //stores all the graphs currently on the page
 nv.logs = {}; //stores some statistics and potential error messages
+nv.dom = {}; //DOM manipulation functions
 
 nv.dispatch = d3.dispatch('render_start', 'render_end');
 

--- a/src/dom.js
+++ b/src/dom.js
@@ -5,7 +5,9 @@
  * implementations in the future.
  */
 nv.dom.write = function(callback) {
-	if (typeof(window.fastdom) !== 'undefined') return fastdom.write(callback);
+	if (window.fastdom !== undefined) {
+		return fastdom.write(callback);
+	}
 	return callback();
 };
 
@@ -16,6 +18,8 @@ nv.dom.write = function(callback) {
  * implementations in the future.
  */
 nv.dom.read = function(callback) {
-	if (typeof(window.fastdom) !== 'undefined') return fastdom.read(callback);
+	if (window.fastdom !== undefined) {
+		return fastdom.read(callback);
+	}
 	return callback();
 };

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,0 +1,21 @@
+/* Facade for queueing DOM write operations
+ * with Fastdom (https://github.com/wilsonpage/fastdom)
+ * if available.
+ * This could easily be extended to support alternate
+ * implementations in the future.
+ */
+nv.dom.write = function(callback) {
+	if (typeof(window.fastdom) !== 'undefined') return fastdom.write(callback);
+	return callback();
+};
+
+/* Facade for queueing DOM read operations
+ * with Fastdom (https://github.com/wilsonpage/fastdom)
+ * if available.
+ * This could easily be extended to support alternate
+ * implementations in the future.
+ */
+nv.dom.read = function(callback) {
+	if (typeof(window.fastdom) !== 'undefined') return fastdom.read(callback);
+	return callback();
+};

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -97,7 +97,8 @@ nv.interactiveGuideline = function() {
                     if (isMSIE) {
                         if (d3.event.relatedTarget
                             && d3.event.relatedTarget.ownerSVGElement === undefined
-                            && d3.event.relatedTarget.className.match(tooltip.nvPointerEventsClass)) {
+                            && (d3.event.relatedTarget.className === undefined
+                                || d3.event.relatedTarget.className.match(tooltip.nvPointerEventsClass))) {
 
                             return;
                         }

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -144,23 +144,24 @@ nv.interactiveGuideline = function() {
                 .on("click", mouseHandler)
             ;
 
+            layer.guideLine = null;
             //Draws a vertical guideline at the given X postion.
             layer.renderGuideLine = function(x) {
                 if (!showGuideLine) return;
-                var line = wrap.select(".nv-interactiveGuideLine")
-                    .selectAll("line")
-                    .data((x != null) ? [nv.utils.NaNtoZero(x)] : [], String);
-
-                line.enter()
-                    .append("line")
-                    .attr("class", "nv-guideline")
-                    .attr("x1", function(d) { return d;})
-                    .attr("x2", function(d) { return d;})
-                    .attr("y1", availableHeight)
-                    .attr("y2",0)
-                ;
-                line.exit().remove();
-
+                if (layer.guideLine && layer.guideLine.attr("x1") === x) return;
+                fastdom.write(function() {
+                    var line = wrap.select(".nv-interactiveGuideLine")
+                        .selectAll("line")
+                        .data((x != null) ? [nv.utils.NaNtoZero(x)] : [], String);
+                    line.enter()
+                        .append("line")
+                        .attr("class", "nv-guideline")
+                        .attr("x1", function(d) { return d;})
+                        .attr("x2", function(d) { return d;})
+                        .attr("y1", availableHeight)
+                        .attr("y2",0);
+                    line.exit().remove();
+                });
             }
         });
     }

--- a/src/interactiveLayer.js
+++ b/src/interactiveLayer.js
@@ -149,7 +149,7 @@ nv.interactiveGuideline = function() {
             layer.renderGuideLine = function(x) {
                 if (!showGuideLine) return;
                 if (layer.guideLine && layer.guideLine.attr("x1") === x) return;
-                fastdom.write(function() {
+                nv.dom.write(function() {
                     var line = wrap.select(".nv-interactiveGuideLine")
                         .selectAll("line")
                         .data((x != null) ? [nv.utils.NaNtoZero(x)] : [], String);

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -402,12 +402,16 @@ nv.models.scatter = function() {
     // utility function calls provided by this chart
     chart._calls = new function() {
         this.clearHighlights = function () {
-            d3.selectAll(".nv-chart-" + id + " .nv-point.hover").classed("hover", false);
+            fastdom.write(function() {
+                d3.selectAll(".nv-chart-" + id + " .nv-point.hover").classed("hover", false);
+            });
             return null;
         };
         this.highlightPoint = function (seriesIndex, pointIndex, isHoverOver) {
-            d3.select(".nv-chart-" + id + " .nv-series-" + seriesIndex + " .nv-point-" + pointIndex)
-                .classed("hover", isHoverOver);
+            fastdom.write(function() {
+                var node = document.querySelector(".nv-chart-" + id + " .nv-series-" + seriesIndex + " .nv-point-" + pointIndex);
+                d3.select(node).classed("hover", isHoverOver);
+            });
         };
     };
 

--- a/src/models/scatter.js
+++ b/src/models/scatter.js
@@ -402,13 +402,13 @@ nv.models.scatter = function() {
     // utility function calls provided by this chart
     chart._calls = new function() {
         this.clearHighlights = function () {
-            fastdom.write(function() {
+            nv.dom.write(function() {
                 d3.selectAll(".nv-chart-" + id + " .nv-point.hover").classed("hover", false);
             });
             return null;
         };
         this.highlightPoint = function (seriesIndex, pointIndex, isHoverOver) {
-            fastdom.write(function() {
+            nv.dom.write(function() {
                 var node = document.querySelector(".nv-chart-" + id + " .nv-series-" + seriesIndex + " .nv-point-" + pointIndex);
                 d3.select(node).classed("hover", isHoverOver);
             });

--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -35,6 +35,7 @@ svg.nvd3-svg {
   padding: 1px;
   border: 1px solid rgba(0,0,0,.2);
   z-index: 10000;
+  display: block;
 
   font-family: Arial;
   font-size: 13px;
@@ -134,8 +135,8 @@ svg.nvd3-svg {
 }
 
 .nvtooltip-pending-removal {
-  position: absolute;
   pointer-events: none;
+  display: none;
 }
 
 .nvd3 text {

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -62,11 +62,11 @@
         //By default, the tooltip model renders a beautiful table inside a DIV.
         //You can override this function if a custom tooltip is desired.
         var contentGenerator = function(d) {
-            if (content != null) {
+            if (content !== null) {
                 return content;
             }
 
-            if (d == null) {
+            if (d === null) {
                 return '';
             }
 
@@ -141,7 +141,7 @@
                 var viewBox = (svg.node()) ? svg.attr('viewBox') : null;
                 if (viewBox) {
                     viewBox = viewBox.split(' ');
-                    var ratio = parseInt(svg.style('width')) / viewBox[2];
+                    var ratio = parseInt(svg.style('width'), 10) / viewBox[2];
 
                     position.left = position.left * ratio;
                     position.top  = position.top * ratio;
@@ -189,7 +189,7 @@
             convertViewBoxRatio();
 
             var left = position.left;
-            var top = (fixedTop != null) ? fixedTop : position.top;
+            var top = (fixedTop !== null) ? fixedTop : position.top;
 
             fastdom.write(function () {
                 var container = getTooltipContainer(contentGenerator(data));
@@ -382,7 +382,7 @@
             if( !isNaN( Elem.offsetTop ) ) {
                 offsetTop += (Elem.offsetTop);
             }
-        } while( Elem = Elem.offsetParent );
+        } while( Elem === Elem.offsetParent );
         return offsetTop;
     };
 
@@ -395,7 +395,7 @@
             if( !isNaN( Elem.offsetLeft ) ) {
                 offsetLeft += (Elem.offsetLeft);
             }
-        } while( Elem = Elem.offsetParent );
+        } while( Elem === Elem.offsetParent );
         return offsetLeft;
     };
 
@@ -406,8 +406,8 @@
     //container = tooltip DIV
     nv.tooltip.calcTooltipPosition = function(pos, gravity, dist, container) {
         fastdom.read(function() {
-            var height = parseInt(container.offsetHeight),
-                width = parseInt(container.offsetWidth),
+            var height = parseInt(container.offsetHeight, 10),
+                width = parseInt(container.offsetWidth, 10),
                 windowWidth = nv.utils.windowSize().width,
                 windowHeight = nv.utils.windowSize().height,
                 scrollTop = window.pageYOffset,
@@ -428,12 +428,13 @@
                 return nv.tooltip.findTotalOffsetLeft(Elem,left);
             };
 
+            var tLeft, tTop;
             switch (gravity) {
                 case 'e':
                     left = pos[0] - width - dist;
                     top = pos[1] - (height / 2);
-                    var tLeft = tooltipLeft(container);
-                    var tTop = tooltipTop(container);
+                    tLeft = tooltipLeft(container);
+                    tTop = tooltipTop(container);
                     if (tLeft < scrollLeft) left = pos[0] + dist > scrollLeft ? pos[0] + dist : scrollLeft - tLeft + left;
                     if (tTop < scrollTop) top = scrollTop - tTop + top;
                     if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
@@ -441,8 +442,8 @@
                 case 'w':
                     left = pos[0] + dist;
                     top = pos[1] - (height / 2);
-                    var tLeft = tooltipLeft(container);
-                    var tTop = tooltipTop(container);
+                    tLeft = tooltipLeft(container);
+                    tTop = tooltipTop(container);
                     if (tLeft + width > windowWidth) left = pos[0] - width - dist;
                     if (tTop < scrollTop) top = scrollTop + 5;
                     if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
@@ -450,8 +451,8 @@
                 case 'n':
                     left = pos[0] - (width / 2) - 5;
                     top = pos[1] + dist;
-                    var tLeft = tooltipLeft(container);
-                    var tTop = tooltipTop(container);
+                    tLeft = tooltipLeft(container);
+                    tTop = tooltipTop(container);
                     if (tLeft < scrollLeft) left = scrollLeft + 5;
                     if (tLeft + width > windowWidth) left = left - width/2 + 5;
                     if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
@@ -459,8 +460,8 @@
                 case 's':
                     left = pos[0] - (width / 2);
                     top = pos[1] - height - dist;
-                    var tLeft = tooltipLeft(container);
-                    var tTop = tooltipTop(container);
+                    tLeft = tooltipLeft(container);
+                    tTop = tooltipTop(container);
                     if (tLeft < scrollLeft) left = scrollLeft + 5;
                     if (tLeft + width > windowWidth) left = left - width/2 + 5;
                     if (scrollTop > tTop) top = scrollTop;
@@ -468,8 +469,8 @@
                 case 'none':
                     left = pos[0];
                     top = pos[1] - dist;
-                    var tLeft = tooltipLeft(container);
-                    var tTop = tooltipTop(container);
+                    tLeft = tooltipLeft(container);
+                    tTop = tooltipTop(container);
                     break;
             }
 

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -150,28 +150,35 @@
         }
 
         //Creates new tooltip container, or uses existing one on DOM.
-        function getTooltipContainer(newContent) {
-            var body;
-            if (chartContainer) {
-                body = d3.select(chartContainer);
-            } else {
-                body = d3.select("body");
-            }
-
-            var container = body.select(".nvtooltip");
-            if (container.node() === null) {
+        function getTooltipContainer() {
+            var container = document.getElementById(id);
+            if (container === null) {
+                var body;
+                if (chartContainer) {
+                    body = chartContainer;
+                } else {
+                    body = document.body;
+                }
                 //Create new tooltip div if it doesn't exist on DOM.
-                container = body.append("div")
-                    .attr("class", "nvtooltip " + (classes? classes: "xy-tooltip"))
-                    .attr("id",id)
-                ;
+                var t = d3.select(body).append("div")
+                          .attr("class", "nvtooltip " + (classes? classes: "xy-tooltip"))
+                          .attr("id",id);
+                t.style("top",0).style("left",0).style("opacity",0);
+                t.selectAll("div, table, td, tr").classed(nvPointerEventsClass,true)
+                t.classed(nvPointerEventsClass,true);
+                container = t.node();
             }
 
-            container.node().innerHTML = newContent;
-            container.style("top",0).style("left",0).style("opacity",0);
-            container.selectAll("div, table, td, tr").classed(nvPointerEventsClass,true)
-            container.classed(nvPointerEventsClass,true);
-            return container.node();
+            // Bonus - If you override contentGenerator and return falsey you can use something like
+            //         React or Knockout to bind the data for your tooltip
+            var newContent = contentGenerator(data);
+            if (newContent) container.innerHTML = newContent;
+
+            var hidden = document.querySelector("#" + id + ".nvtooltip-pending-removal");
+            if (hidden)
+                hidden.className = "nvtooltip " + (classes? classes: "xy-tooltip");
+
+            return container;
         }
 
         //Draw the tooltip onto the DOM.
@@ -183,39 +190,46 @@
 
             var left = position.left;
             var top = (fixedTop != null) ? fixedTop : position.top;
-            var container = getTooltipContainer(contentGenerator(data));
-            tooltipElem = container;
-            if (chartContainer) {
-                var svgComp = chartContainer.getElementsByTagName("svg")[0];
-                var boundRect = (svgComp) ? svgComp.getBoundingClientRect() : chartContainer.getBoundingClientRect();
-                var svgOffset = {left:0,top:0};
-                if (svgComp) {
-                    var svgBound = svgComp.getBoundingClientRect();
-                    var chartBound = chartContainer.getBoundingClientRect();
-                    var svgBoundTop = svgBound.top;
 
-                    //Defensive code. Sometimes, svgBoundTop can be a really negative
-                    //  number, like -134254. That's a bug.
-                    //  If such a number is found, use zero instead. FireFox bug only
-                    if (svgBoundTop < 0) {
-                        var containerBound = chartContainer.getBoundingClientRect();
-                        svgBoundTop = (Math.abs(svgBoundTop) > containerBound.height) ? 0 : svgBoundTop;
-                    }
-                    svgOffset.top = Math.abs(svgBoundTop - chartBound.top);
-                    svgOffset.left = Math.abs(svgBound.left - chartBound.left);
+            fastdom.write(function () {
+                var container = getTooltipContainer(contentGenerator(data));
+                tooltipElem = container;
+                if (chartContainer) {
+                    fastdom.read(function() {
+                        var svgComp = chartContainer.getElementsByTagName("svg")[0];
+                        var boundRect = (svgComp) ? svgComp.getBoundingClientRect() : chartContainer.getBoundingClientRect();
+                        var svgOffset = {left:0,top:0};
+                        if (svgComp) {
+                            var svgBound = svgComp.getBoundingClientRect();
+                            var chartBound = chartContainer.getBoundingClientRect();
+                            var svgBoundTop = svgBound.top;
+
+                            //Defensive code. Sometimes, svgBoundTop can be a really negative
+                            //  number, like -134254. That's a bug.
+                            //  If such a number is found, use zero instead. FireFox bug only
+                            if (svgBoundTop < 0) {
+                                var containerBound = chartContainer.getBoundingClientRect();
+                                svgBoundTop = (Math.abs(svgBoundTop) > containerBound.height) ? 0 : svgBoundTop;
+                            }
+                            svgOffset.top = Math.abs(svgBoundTop - chartBound.top);
+                            svgOffset.left = Math.abs(svgBound.left - chartBound.left);
+                        }
+                        //If the parent container is an overflow <div> with scrollbars, subtract the scroll offsets.
+                        //You need to also add any offset between the <svg> element and its containing <div>
+                        //Finally, add any offset of the containing <div> on the whole page.
+                        left += chartContainer.offsetLeft + svgOffset.left - 2*chartContainer.scrollLeft;
+                        top += chartContainer.offsetTop + svgOffset.top - 2*chartContainer.scrollTop;
+                        if (snapDistance && snapDistance > 0) {
+                            top = Math.floor(top/snapDistance) * snapDistance;
+                        }
+
+                        nv.tooltip.calcTooltipPosition([left,top], gravity, distance, container);
+                    });
+                } else {
+                    nv.tooltip.calcTooltipPosition([left,top], gravity, distance, container);
                 }
-                //If the parent container is an overflow <div> with scrollbars, subtract the scroll offsets.
-                //You need to also add any offset between the <svg> element and its containing <div>
-                //Finally, add any offset of the containing <div> on the whole page.
-                left += chartContainer.offsetLeft + svgOffset.left - 2*chartContainer.scrollLeft;
-                top += chartContainer.offsetTop + svgOffset.top - 2*chartContainer.scrollTop;
-            }
+            });
 
-            if (snapDistance && snapDistance > 0) {
-                top = Math.floor(top/snapDistance) * snapDistance;
-            }
-
-            nv.tooltip.calcTooltipPosition([left,top], gravity, distance, container);
             return nvtooltip;
         }
 
@@ -391,102 +405,95 @@
     //dist = how far away from the mouse to place tooltip
     //container = tooltip DIV
     nv.tooltip.calcTooltipPosition = function(pos, gravity, dist, container) {
+        fastdom.read(function() {
+            var height = parseInt(container.offsetHeight),
+                width = parseInt(container.offsetWidth),
+                windowWidth = nv.utils.windowSize().width,
+                windowHeight = nv.utils.windowSize().height,
+                scrollTop = window.pageYOffset,
+                scrollLeft = window.pageXOffset,
+                left, top;
 
-        var height = parseInt(container.offsetHeight),
-            width = parseInt(container.offsetWidth),
-            windowWidth = nv.utils.windowSize().width,
-            windowHeight = nv.utils.windowSize().height,
-            scrollTop = window.pageYOffset,
-            scrollLeft = window.pageXOffset,
-            left, top;
+            windowHeight = window.innerWidth >= document.body.scrollWidth ? windowHeight : windowHeight - 16;
+            windowWidth = window.innerHeight >= document.body.scrollHeight ? windowWidth : windowWidth - 16;
 
-        windowHeight = window.innerWidth >= document.body.scrollWidth ? windowHeight : windowHeight - 16;
-        windowWidth = window.innerHeight >= document.body.scrollHeight ? windowWidth : windowWidth - 16;
+            gravity = gravity || 's';
+            dist = dist || 20;
 
-        gravity = gravity || 's';
-        dist = dist || 20;
+            var tooltipTop = function ( Elem ) {
+                return nv.tooltip.findTotalOffsetTop(Elem, top);
+            };
 
-        var tooltipTop = function ( Elem ) {
-            return nv.tooltip.findTotalOffsetTop(Elem, top);
-        };
+            var tooltipLeft = function ( Elem ) {
+                return nv.tooltip.findTotalOffsetLeft(Elem,left);
+            };
 
-        var tooltipLeft = function ( Elem ) {
-            return nv.tooltip.findTotalOffsetLeft(Elem,left);
-        };
+            switch (gravity) {
+                case 'e':
+                    left = pos[0] - width - dist;
+                    top = pos[1] - (height / 2);
+                    var tLeft = tooltipLeft(container);
+                    var tTop = tooltipTop(container);
+                    if (tLeft < scrollLeft) left = pos[0] + dist > scrollLeft ? pos[0] + dist : scrollLeft - tLeft + left;
+                    if (tTop < scrollTop) top = scrollTop - tTop + top;
+                    if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
+                    break;
+                case 'w':
+                    left = pos[0] + dist;
+                    top = pos[1] - (height / 2);
+                    var tLeft = tooltipLeft(container);
+                    var tTop = tooltipTop(container);
+                    if (tLeft + width > windowWidth) left = pos[0] - width - dist;
+                    if (tTop < scrollTop) top = scrollTop + 5;
+                    if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
+                    break;
+                case 'n':
+                    left = pos[0] - (width / 2) - 5;
+                    top = pos[1] + dist;
+                    var tLeft = tooltipLeft(container);
+                    var tTop = tooltipTop(container);
+                    if (tLeft < scrollLeft) left = scrollLeft + 5;
+                    if (tLeft + width > windowWidth) left = left - width/2 + 5;
+                    if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
+                    break;
+                case 's':
+                    left = pos[0] - (width / 2);
+                    top = pos[1] - height - dist;
+                    var tLeft = tooltipLeft(container);
+                    var tTop = tooltipTop(container);
+                    if (tLeft < scrollLeft) left = scrollLeft + 5;
+                    if (tLeft + width > windowWidth) left = left - width/2 + 5;
+                    if (scrollTop > tTop) top = scrollTop;
+                    break;
+                case 'none':
+                    left = pos[0];
+                    top = pos[1] - dist;
+                    var tLeft = tooltipLeft(container);
+                    var tTop = tooltipTop(container);
+                    break;
+            }
 
-        switch (gravity) {
-            case 'e':
-                left = pos[0] - width - dist;
-                top = pos[1] - (height / 2);
-                var tLeft = tooltipLeft(container);
-                var tTop = tooltipTop(container);
-                if (tLeft < scrollLeft) left = pos[0] + dist > scrollLeft ? pos[0] + dist : scrollLeft - tLeft + left;
-                if (tTop < scrollTop) top = scrollTop - tTop + top;
-                if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
-                break;
-            case 'w':
-                left = pos[0] + dist;
-                top = pos[1] - (height / 2);
-                var tLeft = tooltipLeft(container);
-                var tTop = tooltipTop(container);
-                if (tLeft + width > windowWidth) left = pos[0] - width - dist;
-                if (tTop < scrollTop) top = scrollTop + 5;
-                if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
-                break;
-            case 'n':
-                left = pos[0] - (width / 2) - 5;
-                top = pos[1] + dist;
-                var tLeft = tooltipLeft(container);
-                var tTop = tooltipTop(container);
-                if (tLeft < scrollLeft) left = scrollLeft + 5;
-                if (tLeft + width > windowWidth) left = left - width/2 + 5;
-                if (tTop + height > scrollTop + windowHeight) top = scrollTop + windowHeight - tTop + top - height;
-                break;
-            case 's':
-                left = pos[0] - (width / 2);
-                top = pos[1] - height - dist;
-                var tLeft = tooltipLeft(container);
-                var tTop = tooltipTop(container);
-                if (tLeft < scrollLeft) left = scrollLeft + 5;
-                if (tLeft + width > windowWidth) left = left - width/2 + 5;
-                if (scrollTop > tTop) top = scrollTop;
-                break;
-            case 'none':
-                left = pos[0];
-                top = pos[1] - dist;
-                var tLeft = tooltipLeft(container);
-                var tTop = tooltipTop(container);
-                break;
-        }
-
-        container.style.left = left+'px';
-        container.style.top = top+'px';
-        container.style.opacity = 1;
-        container.style.position = 'absolute';
+            var opacity = container.style.opacity;
+            fastdom.write(function() {
+                var translate = 'translate(' + left + 'px, ' + top + 'px)';
+                container.style.transform = translate;
+                if (opacity != 1) container.style.opacity = 1;
+            });
+        });
 
         return container;
     };
 
     //Global utility function to remove tooltips from the DOM.
     nv.tooltip.cleanup = function() {
-
         // Find the tooltips, mark them for removal by this class (so others cleanups won't find it)
-        var tooltips = document.getElementsByClassName('nvtooltip');
-        var purging = [];
-        while(tooltips.length) {
-            purging.push(tooltips[0]);
-            tooltips[0].style.transitionDelay = '0 !important';
-            tooltips[0].style.opacity = 0;
-            tooltips[0].className = 'nvtooltip-pending-removal';
+        var tooltips = document.querySelectorAll('.nvtooltip');
+        if (tooltips) {
+            fastdom.write(function() {
+                for (var i = 0; i < tooltips.length; i++) {
+                    tooltips[i].className = 'nvtooltip-pending-removal';
+                }
+            });
         }
-
-        setTimeout(function() {
-
-            while (purging.length) {
-                var removeMe = purging.pop();
-                removeMe.parentNode.removeChild(removeMe);
-            }
-        }, 500);
     };
-
 })();

--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -191,11 +191,11 @@
             var left = position.left;
             var top = (fixedTop !== null) ? fixedTop : position.top;
 
-            fastdom.write(function () {
+            nv.dom.write(function () {
                 var container = getTooltipContainer(contentGenerator(data));
                 tooltipElem = container;
                 if (chartContainer) {
-                    fastdom.read(function() {
+                    nv.dom.read(function() {
                         var svgComp = chartContainer.getElementsByTagName("svg")[0];
                         var boundRect = (svgComp) ? svgComp.getBoundingClientRect() : chartContainer.getBoundingClientRect();
                         var svgOffset = {left:0,top:0};
@@ -405,7 +405,7 @@
     //dist = how far away from the mouse to place tooltip
     //container = tooltip DIV
     nv.tooltip.calcTooltipPosition = function(pos, gravity, dist, container) {
-        fastdom.read(function() {
+        nv.dom.read(function() {
             var height = parseInt(container.offsetHeight, 10),
                 width = parseInt(container.offsetWidth, 10),
                 windowWidth = nv.utils.windowSize().width,
@@ -475,7 +475,7 @@
             }
 
             var opacity = container.style.opacity;
-            fastdom.write(function() {
+            nv.dom.write(function() {
                 var translate = 'translate(' + left + 'px, ' + top + 'px)';
                 container.style.transform = translate;
                 if (opacity != 1) container.style.opacity = 1;
@@ -490,7 +490,7 @@
         // Find the tooltips, mark them for removal by this class (so others cleanups won't find it)
         var tooltips = document.querySelectorAll('.nvtooltip');
         if (tooltips) {
-            fastdom.write(function() {
+            nv.dom.write(function() {
                 for (var i = 0; i < tooltips.length; i++) {
                     tooltips[i].className = 'nvtooltip-pending-removal';
                 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,10 +9,11 @@ nv.utils.windowSize = function() {
     // Sane defaults
     var size = {width: 640, height: 480};
 
-    // Earlier IE uses Doc.body
-    if (document.body && document.body.offsetWidth) {
-        size.width = document.body.offsetWidth;
-        size.height = document.body.offsetHeight;
+    // Most recent browsers use
+    if (window.innerWidth && window.innerHeight) {
+        size.width = window.innerWidth;
+        size.height = window.innerHeight;
+        return (size);
     }
 
     // IE can use depending on mode it is in
@@ -22,16 +23,18 @@ nv.utils.windowSize = function() {
 
         size.width = document.documentElement.offsetWidth;
         size.height = document.documentElement.offsetHeight;
+        return (size);
     }
 
-    // Most recent browsers use
-    if (window.innerWidth && window.innerHeight) {
-        size.width = window.innerWidth;
-        size.height = window.innerHeight;
+    // Earlier IE uses Doc.body
+    if (document.body && document.body.offsetWidth) {
+        size.width = document.body.offsetWidth;
+        size.height = document.body.offsetHeight;
+        return (size);
     }
+
     return (size);
 };
-
 
 /*
 Binds callback function to run when window is resized

--- a/src/utils.js
+++ b/src/utils.js
@@ -160,7 +160,7 @@ nv.utils.calcApproxTextWidth = function (svgTextElem) {
     if (typeof svgTextElem.style === 'function'
         && typeof svgTextElem.text === 'function') {
 
-        var fontSize = parseInt(svgTextElem.style("font-size").replace("px",""));
+        var fontSize = parseInt(svgTextElem.style("font-size").replace("px",""), 10);
         var textLength = svgTextElem.text().length;
         return textLength * fontSize * 0.5;
     }
@@ -289,7 +289,7 @@ gives:  {a: 2, b: 3, c: 4}
 nv.utils.deepExtend = function(dst){
     var sources = arguments.length > 1 ? [].slice.call(arguments, 1) : [];
     sources.forEach(function(source) {
-        for (key in source) {
+        for (var key in source) {
             var isArray = dst[key] instanceof Array;
             var isObject = typeof dst[key] === 'object';
             var srcObj = typeof source[key] === 'object';


### PR DESCRIPTION
I've created a series of changes that bring non-webkit (FF, IE 10+) performance up to par with webkit browsers. This was done mainly through the use of requestAnimationFrame, and batching DOM reads and writes into groups to prevent DOM thrashing. This was done using the [fastdom](https://github.com/wilsonpage/fastdom) library. It does bring fastdom in as a dependency, but I really do feel that the benefits outweigh the downsides to adding another dependency.

In my testing, which includes ~1000 x values for 4 series, I brought IE 11 up from a dismal 5-10 FPS to 50-60 FPS. This can be made nearly a solid 60 FPS if you swap out the content generator function with a React component. This was made possible by checking the return value of the content generator function for a falsey value, thus if you return false or null in your overridden content generator it will allow you to use something like React in your app to generate your tooltip content.

I also eliminated unnecessary creating/destroying of elements, such as the tooltip container, where possible. Further optimizations are possible by caching certain CSS values that trigger a style calculation (offsetwidth/height, innerwidth/height, [etc.](http://gent.ilcore.com/2011/03/how-not-to-trigger-layout-in-webkit.html)), but I didn't take it that far as simply reducing thrashing was more or less sufficient to achieve acceptable framerates.

**I did break a test for the line chart guideline** which I plan on fixing shortly (a race condition due to using fastdom I'm sure), but I wanted to get this out there for discussion and review in the meantime.

Please share your thoughts, not expecting this to be merged without some discussion first mainly due to the added dependency on fastdom.