### PR TITLE
Added option to disable barColor functionality...

### DIFF
--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -20,7 +20,7 @@ nv.models.multiBar = function() {
         , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
         , color = nv.utils.defaultColor()
         , hideable = false
-        , barColor = null // adding the ability to set the color for each rather than the whole group
+        , barColor = undefined // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , duration = 500
         , xDomain
@@ -342,6 +342,9 @@ nv.models.multiBar = function() {
         }},
         barColor:  {get: function(){return barColor;}, set: function(_){
             barColor = nv.utils.getColor(_);
+        }},
+        disableBarColor:  {get: function(){return barColor === undefined;}, set: function(_){
+            barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -20,7 +20,7 @@ nv.models.multiBar = function() {
         , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
         , color = nv.utils.defaultColor()
         , hideable = false
-        , barColor = undefined // adding the ability to set the color for each rather than the whole group
+        , barColor = null // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , duration = 500
         , xDomain
@@ -341,10 +341,7 @@ nv.models.multiBar = function() {
             color = nv.utils.getColor(_);
         }},
         barColor:  {get: function(){return barColor;}, set: function(_){
-            barColor = nv.utils.getColor(_);
-        }},
-        disableBarColor:  {get: function(){return barColor === undefined;}, set: function(_){
-            barColor = _?undefined:nv.utils.getColor();
+            barColor = _ ? nv.utils.getColor(_) : null;
         }}
     });
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -179,7 +179,7 @@ nv.models.multiBarChart = function() {
             if (showLegend) {
                 legend.width(availableWidth - controlWidth());
 
-                if (multibar.barColor())
+                if (multibar.barColor)
                     data.forEach(function(series,i) {
                         series.color = d3.rgb('#ccc').darker(i * 1.5).toString();
                     });
@@ -430,6 +430,9 @@ nv.models.multiBarChart = function() {
         rightAlignYAxis: {get: function(){return rightAlignYAxis;}, set: function(_){
             rightAlignYAxis = _;
             yAxis.orient( rightAlignYAxis ? 'right' : 'left');
+        }},
+        disableBarColor:  {get: function(){return multibar.barColor === undefined;}, set: function(_){
+            multibar.barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -16,7 +16,7 @@ nv.models.multiBarChart = function() {
     var margin = {top: 30, right: 20, bottom: 50, left: 60}
         , width = null
         , height = null
-        , color = nv.utils.defaultColor()
+        , color = nv.utils.getColor(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
         , showControls = true
         , controlLabels = {}
         , showLegend = true
@@ -43,6 +43,8 @@ nv.models.multiBarChart = function() {
 
     state.stacked = false // DEPRECATED Maintained for backward compatibility
 
+    legend.color(color);
+    
     multibar
         .stacked(false)
     ;

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -179,11 +179,6 @@ nv.models.multiBarChart = function() {
             if (showLegend) {
                 legend.width(availableWidth - controlWidth());
 
-                if (multibar.barColor)
-                    data.forEach(function(series,i) {
-                        series.color = d3.rgb('#ccc').darker(i * 1.5).toString();
-                    });
-
                 g.select('.nv-legendWrap')
                     .datum(data)
                     .call(legend);
@@ -430,9 +425,6 @@ nv.models.multiBarChart = function() {
         rightAlignYAxis: {get: function(){return rightAlignYAxis;}, set: function(_){
             rightAlignYAxis = _;
             yAxis.orient( rightAlignYAxis ? 'right' : 'left');
-        }},
-        disableBarColor:  {get: function(){return multibar.barColor === undefined;}, set: function(_){
-            multibar.barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -16,7 +16,7 @@ nv.models.multiBarChart = function() {
     var margin = {top: 30, right: 20, bottom: 50, left: 60}
         , width = null
         , height = null
-        , color = nv.utils.getColor(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
+        , color = nv.utils.defaultColor()
         , showControls = true
         , controlLabels = {}
         , showLegend = true
@@ -42,8 +42,6 @@ nv.models.multiBarChart = function() {
         ;
 
     state.stacked = false // DEPRECATED Maintained for backward compatibility
-
-    legend.color(color);
     
     multibar
         .stacked(false)
@@ -427,6 +425,10 @@ nv.models.multiBarChart = function() {
         rightAlignYAxis: {get: function(){return rightAlignYAxis;}, set: function(_){
             rightAlignYAxis = _;
             yAxis.orient( rightAlignYAxis ? 'right' : 'left');
+        }},
+        barColor:  {get: function(){return multibar.barColor;}, set: function(_){
+            multibar.barColor(_);
+            legend.color(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
         }}
     });
 

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -342,7 +342,7 @@ nv.models.multiBarHorizontal = function() {
         color:  {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);
         }},
-        barColor:  {get: function(){return color;}, set: function(_){
+        barColor:  {get: function(){return barColor;}, set: function(_){
             barColor = _ ? nv.utils.getColor(_) : null;
         }}
     });

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -17,7 +17,7 @@ nv.models.multiBarHorizontal = function() {
         , getYerr = function(d) { return d.yErr }
         , forceY = [0] // 0 is forced by default.. this makes sense for the majority of bar graphs... user can always do chart.forceY([]) to remove
         , color = nv.utils.defaultColor()
-        , barColor = undefined // adding the ability to set the color for each rather than the whole group
+        , barColor = null // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , stacked = false
         , showValues = false
@@ -343,10 +343,7 @@ nv.models.multiBarHorizontal = function() {
             color = nv.utils.getColor(_);
         }},
         barColor:  {get: function(){return color;}, set: function(_){
-            barColor = nv.utils.getColor(_);
-        }},
-        disableBarColor:  {get: function(){return barColor === undefined;}, set: function(_){
-            barColor = _?undefined:nv.utils.getColor();
+            barColor = _ ? nv.utils.getColor(_) : null;
         }}
     });
 

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -17,7 +17,7 @@ nv.models.multiBarHorizontal = function() {
         , getYerr = function(d) { return d.yErr }
         , forceY = [0] // 0 is forced by default.. this makes sense for the majority of bar graphs... user can always do chart.forceY([]) to remove
         , color = nv.utils.defaultColor()
-        , barColor = null // adding the ability to set the color for each rather than the whole group
+        , barColor = undefined // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , stacked = false
         , showValues = false
@@ -344,6 +344,9 @@ nv.models.multiBarHorizontal = function() {
         }},
         barColor:  {get: function(){return color;}, set: function(_){
             barColor = nv.utils.getColor(_);
+        }},
+        disableBarColor:  {get: function(){return barColor === undefined;}, set: function(_){
+            barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -172,11 +172,6 @@ nv.models.multiBarHorizontalChart = function() {
             if (showLegend) {
                 legend.width(availableWidth - controlWidth());
 
-                if (multibar.barColor)
-                    data.forEach(function(series,i) {
-                        series.color = d3.rgb('#ccc').darker(i * 1.5).toString();
-                    });
-
                 g.select('.nv-legendWrap')
                     .datum(data)
                     .call(legend);
@@ -379,9 +374,6 @@ nv.models.multiBarHorizontalChart = function() {
         color:  {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);
             legend.color(color);
-        }},
-        disableBarColor:  {get: function(){return multibar.barColor === undefined;}, set: function(_){
-            multibar.barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -172,7 +172,7 @@ nv.models.multiBarHorizontalChart = function() {
             if (showLegend) {
                 legend.width(availableWidth - controlWidth());
 
-                if (multibar.barColor())
+                if (multibar.barColor)
                     data.forEach(function(series,i) {
                         series.color = d3.rgb('#ccc').darker(i * 1.5).toString();
                     });
@@ -379,6 +379,9 @@ nv.models.multiBarHorizontalChart = function() {
         color:  {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);
             legend.color(color);
+        }},
+        disableBarColor:  {get: function(){return multibar.barColor === undefined;}, set: function(_){
+            multibar.barColor = _?undefined:nv.utils.getColor();
         }}
     });
 

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -16,7 +16,7 @@ nv.models.multiBarHorizontalChart = function() {
     var margin = {top: 30, right: 20, bottom: 50, left: 60}
         , width = null
         , height = null
-        , color = nv.utils.getColor(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
+        , color = nv.utils.defaultColor()
         , showControls = true
         , controlLabels = {}
         , showLegend = true
@@ -40,8 +40,6 @@ nv.models.multiBarHorizontalChart = function() {
 
     state.stacked = false; // DEPRECATED Maintained for backward compatibility
     
-    legend.color(color);
-
     multibar
         .stacked(stacked)
     ;
@@ -376,6 +374,10 @@ nv.models.multiBarHorizontalChart = function() {
         color:  {get: function(){return color;}, set: function(_){
             color = nv.utils.getColor(_);
             legend.color(color);
+        }},
+        barColor:  {get: function(){return multibar.barColor;}, set: function(_){
+            multibar.barColor(_);
+            legend.color(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
         }}
     });
 

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -16,7 +16,7 @@ nv.models.multiBarHorizontalChart = function() {
     var margin = {top: 30, right: 20, bottom: 50, left: 60}
         , width = null
         , height = null
-        , color = nv.utils.defaultColor()
+        , color = nv.utils.getColor(function(d,i) {return d3.rgb('#ccc').darker(i * 1.5).toString();})
         , showControls = true
         , controlLabels = {}
         , showLegend = true
@@ -39,6 +39,8 @@ nv.models.multiBarHorizontalChart = function() {
         ;
 
     state.stacked = false; // DEPRECATED Maintained for backward compatibility
+    
+    legend.color(color);
 
     multibar
         .stacked(stacked)

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -31,6 +31,7 @@ nv.models.stackedAreaChart = function() {
         }
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
+        , yAxisTickFormat = d3.format(',.2f')
         , state = nv.utils.state()
         , defaultState = null
         , noData = 'No Data Available.'
@@ -275,7 +276,7 @@ nv.models.stackedAreaChart = function() {
                     .ticks(stacked.offset() == 'wiggle' ? 0 : nv.utils.calcTicksY(availableHeight/36, data) )
                     .tickSize(-availableWidth, 0)
                     .setTickFormat( (stacked.style() == 'expand' || stacked.style() == 'stack_percent')
-                        ? d3.format('%') : yAxis.tickFormat());
+                        ? d3.format('%') : yAxisTickFormat);
 
                 g.select('.nv-y.nv-axis')
                     .transition().duration(0)
@@ -481,6 +482,7 @@ nv.models.stackedAreaChart = function() {
         noData:    {get: function(){return noData;}, set: function(_){noData=_;}},
         showControls:    {get: function(){return showControls;}, set: function(_){showControls=_;}},
         controlLabels:    {get: function(){return controlLabels;}, set: function(_){controlLabels=_;}},
+        yAxisTickFormat:    {get: function(){return yAxisTickFormat;}, set: function(_){yAxisTickFormat=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -31,7 +31,6 @@ nv.models.stackedAreaChart = function() {
         }
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
-        , yAxisTickFormat = d3.format(',.2f')
         , state = nv.utils.state()
         , defaultState = null
         , noData = 'No Data Available.'
@@ -276,7 +275,7 @@ nv.models.stackedAreaChart = function() {
                     .ticks(stacked.offset() == 'wiggle' ? 0 : nv.utils.calcTicksY(availableHeight/36, data) )
                     .tickSize(-availableWidth, 0)
                     .setTickFormat( (stacked.style() == 'expand' || stacked.style() == 'stack_percent')
-                        ? d3.format('%') : yAxisTickFormat);
+                        ? d3.format('%') : yAxis.tickFormat());
 
                 g.select('.nv-y.nv-axis')
                     .transition().duration(0)
@@ -482,7 +481,6 @@ nv.models.stackedAreaChart = function() {
         noData:    {get: function(){return noData;}, set: function(_){noData=_;}},
         showControls:    {get: function(){return showControls;}, set: function(_){showControls=_;}},
         controlLabels:    {get: function(){return controlLabels;}, set: function(_){controlLabels=_;}},
-        yAxisTickFormat:    {get: function(){return yAxisTickFormat;}, set: function(_){yAxisTickFormat=_;}},
 
         // options that require extra logic in the setter
         margin: {get: function(){return margin;}, set: function(_){


### PR DESCRIPTION
to fix functional regression from older versions, where it was possible for each series have its own colour (using color() instead of barColor() to define colours).
Feel free to implement this differently, but I would really appreciate it if the original colouring options were available as well as the new defaults.