### PR TITLE
Unifying multiBar and multiBarHorizontal

### DIFF
--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -300,8 +300,8 @@ nv.models.multiBar = function() {
                             xerr = xerr.length ? xerr : [-Math.abs(xerr), Math.abs(xerr)];
                             var xerrMax = Math.max.apply(null, xerr);
                             var xerrMin = Math.min.apply(null, xerr);
-                            shiftBottom = y(xerrMin) - y(0);
-                            shiftTop = y(xerrMax) - y(0);
+                            shiftBottom = (y(xerrMin) - y(0)) > 0 ? y(xerrMin) - y(0) : 0;
+                            shiftTop = (y(xerrMax) - y(0)) < 0 ? y(xerrMax) - y(0) : 0;
                         }
                         return getY(d,i) < 0 ? y(getY(d,i)) - y(0) + shiftBottom + 5 : shiftTop - 5
                     })

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -300,8 +300,8 @@ nv.models.multiBar = function() {
                             xerr = xerr.length ? xerr : [-Math.abs(xerr), Math.abs(xerr)];
                             var xerrMax = Math.max.apply(null, xerr);
                             var xerrMin = Math.min.apply(null, xerr);
-                            shiftTop = y(xerrMin) - y(0);
-                            shiftBottom = y(xerrMax) - y(0)
+                            shiftBottom = y(xerrMin) - y(0);
+                            shiftTop = y(xerrMax) - y(0);
                         }
                         return getY(d,i) < 0 ? y(getY(d,i)) - y(0) + shiftBottom + 5 : shiftTop - 5
                     })

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -272,7 +272,7 @@ nv.models.multiBar = function() {
 
             if (showValues && !stacked) {
                 bars.select('text')
-                    .attr('text-anchor', function(d,i) { return getY(d,i) > 0 ? 'end' : 'start' })
+                    .attr('text-anchor', function(d,i) { return getY(d,i) < 0 ? 'start' : 'end' })
                     .attr('y', 0 - x.rangeBand() / (data.length * 2))
                     .attr('dy', '.32em')
                     .text(function(d,i) {

--- a/src/models/multiBar.js
+++ b/src/models/multiBar.js
@@ -9,25 +9,30 @@ nv.models.multiBar = function() {
     var margin = {top: 0, right: 0, bottom: 0, left: 0}
         , width = 960
         , height = 500
+        , id = Math.floor(Math.random() * 10000) //Create semi-unique ID in case user doesn't select one
         , x = d3.scale.ordinal()
         , y = d3.scale.linear()
-        , id = Math.floor(Math.random() * 10000) //Create semi-unique ID in case user doesn't select one
         , getX = function(d) { return d.x }
         , getY = function(d) { return d.y }
+        , getXerr = function(d) { return d.xErr }
         , forceY = [0] // 0 is forced by default.. this makes sense for the majority of bar graphs... user can always do chart.forceY([]) to remove
-        , clipEdge = true
-        , stacked = false
-        , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
         , color = nv.utils.defaultColor()
-        , hideable = false
         , barColor = null // adding the ability to set the color for each rather than the whole group
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
-        , duration = 500
+        , stacked = false
+        , showValues = false
+        , clipEdge = true
+        , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
+        , valuePadding = 80
+        , groupSpacing = 0.1
+        , hideable = false
+        , valueFormat = d3.format(',.2f')
+        , delay = 1200
         , xDomain
         , yDomain
         , xRange
         , yRange
-        , groupSpacing = 0.1
+        , duration = 500
         , dispatch = d3.dispatch('chartClick', 'elementClick', 'elementDblClick', 'elementMouseover', 'elementMouseout', 'renderEnd')
         ;
 
@@ -35,11 +40,8 @@ nv.models.multiBar = function() {
     // Private Variables
     //------------------------------------------------------------
 
-    var x0, y0 //used to store previous scales
-        , renderWatch = nv.utils.renderWatch(dispatch, duration)
-        ;
-
-    var last_datalength = 0;
+    var x0, y0; //used to store previous scales
+    var renderWatch = nv.utils.renderWatch(dispatch, duration);
 
     function chart(selection) {
         renderWatch.reset();
@@ -48,13 +50,6 @@ nv.models.multiBar = function() {
                 availableHeight = height - margin.top - margin.bottom,
                 container = d3.select(this);
             nv.utils.initSVG(container);
-
-            // This function defines the requirements for render complete
-            var endFn = function(d, i) {
-                if (d.series === data.length - 1 && i === data[0].values.length - 1)
-                    return true;
-                return false;
-            };
 
             if(hideable && data.length) hideable = [{
                 values: data[0].values.map(function(d) {
@@ -71,7 +66,7 @@ nv.models.multiBar = function() {
                     .offset(stackOffset)
                     .values(function(d){ return d.values })
                     .y(getY)
-                (!data.length && hideable ? hideable : data);
+                (data);
 
 
             //add series index to each data point for reference
@@ -104,29 +99,44 @@ nv.models.multiBar = function() {
             var seriesData = (xDomain && yDomain) ? [] : // if we know xDomain and yDomain, no need to calculate
                 data.map(function(d) {
                     return d.values.map(function(d,i) {
-                        return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1 }
+                        return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1, xerr: getXerr(d,i) }
                     })
                 });
 
             x.domain(xDomain || d3.merge(seriesData).map(function(d) { return d.x }))
                 .rangeBands(xRange || [0, availableWidth], groupSpacing);
 
-            y.domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return stacked ? (d.y > 0 ? d.y1 : d.y1 + d.y ) : d.y }).concat(forceY)))
-                .range(yRange || [availableHeight, 0]);
+            y.domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) {
+                    // return stacked ? (d.y > 0 ? d.y1 : d.y1 + d.y ) : d.y
+                    var xerr = d.xerr.length ? d.xerr : [-Math.abs(d.xerr), Math.abs(d.xerr)];
+                    var xerrMax = Math.max.apply(null, xerr);
+                    var xerrMin = Math.min.apply(null, xerr);
+                    if (stacked){
+                        if (d.y > 0)
+                            return (d.y1 + (xerrMax > 0 ? xerrMax : 0))
+                        else
+                            return (d.y1 + d.y + (xerrMin < 0 ? xerrMin : 0))
+                    }else{
+                        if (d.y > 0)
+                            return (d.y + (xerrMax > 0 ? xerrMax : 0))
+                        else
+                            return (d.y + (xerrMin < 0 ? xerrMin : 0))
+                    }
+                }).concat(forceY)))
 
-            // If scale's domain don't have a range, slightly adjust to make one... so a chart can show a single data point
-            if (x.domain()[0] === x.domain()[1])
-                x.domain()[0] ?
-                    x.domain([x.domain()[0] - x.domain()[0] * 0.01, x.domain()[1] + x.domain()[1] * 0.01])
-                    : x.domain([-1,1]);
-
-            if (y.domain()[0] === y.domain()[1])
-                y.domain()[0] ?
-                    y.domain([y.domain()[0] + y.domain()[0] * 0.01, y.domain()[1] - y.domain()[1] * 0.01])
-                    : y.domain([-1,1]);
+            var offsetTop = 0;
+            var offsetBottom = 0;
+            if (showValues && !stacked) {
+                if (y.domain()[0] < 0)
+                    offsetBottom += valuePadding
+                if (y.domain()[1] > 0)
+                    offsetTop += valuePadding
+                }
+            y.range(yRange || [availableHeight - offsetBottom, 0 + offsetTop]);
 
             x0 = x0 || x;
-            y0 = y0 || y;
+            y0 = y0 || d3.scale.linear().domain(y.domain()).range([y(0),y(0)]);
+
 
             // Setup containers and skeleton of chart
             var wrap = container.selectAll('g.nv-wrap.nv-multibar').data([data]);
@@ -152,43 +162,33 @@ nv.models.multiBar = function() {
             groups.enter().append('g')
                 .style('stroke-opacity', 1e-6)
                 .style('fill-opacity', 1e-6);
-
-            var exitTransition = renderWatch
-                .transition(groups.exit().selectAll('rect.nv-bar'), 'multibarExit', Math.min(100, duration))
-                .attr('y', function(d) { return (stacked ? y0(d.y0) : y0(0)) || 0 })
-                .attr('height', 0)
+            groups.exit().watchTransition(renderWatch, 'multibar: exit groups')
+                .style('stroke-opacity', 1e-6)
+                .style('fill-opacity', 1e-6)
                 .remove();
-            if (exitTransition.delay)
-                exitTransition.delay(function(d,i) {
-                    var delay = i * (duration / (last_datalength + 1)) - i;
-                    return delay;
-                });
             groups
                 .attr('class', function(d,i) { return 'nv-group nv-series-' + i })
                 .classed('hover', function(d) { return d.hover })
                 .style('fill', function(d,i){ return color(d, i) })
                 .style('stroke', function(d,i){ return color(d, i) });
-            groups
+            groups.watchTransition(renderWatch, 'multibar: groups')
                 .style('stroke-opacity', 1)
-                .style('fill-opacity', 0.75);
+                .style('fill-opacity', .75);
 
-            var bars = groups.selectAll('rect.nv-bar')
+            var bars = groups.selectAll('g.nv-bar')
                 .data(function(d) { return (hideable && !data.length) ? hideable.values : d.values });
             bars.exit().remove();
 
-            var barsEnter = bars.enter().append('rect')
-                    .attr('class', function(d,i) { return getY(d,i) < 0 ? 'nv-bar negative' : 'nv-bar positive'})
-                    .attr('x', function(d,i,j) {
-                        return stacked ? 0 : (j * x.rangeBand() / data.length )
-                    })
-                    .attr('y', function(d) { return y0(stacked ? d.y0 : 0) || 0 })
-                    .attr('height', 0)
-                    .attr('width', x.rangeBand() / (stacked ? 1 : data.length) )
-                    .attr('transform', function(d,i) { return 'translate(' + x(getX(d,i)) + ',0)'; })
-                ;
+            var barsEnter = bars.enter().append('g')
+                .attr('transform', function(d,i,j) {
+                    return 'translate(' + y0(stacked ? d.y0 : 0) + ',' + (stacked ? 0 : (j * x.rangeBand() / data.length ) + x(getX(d,i))) + ')'
+                });
+
+            barsEnter.append('rect')
+                .attr('height', 0)
+                .attr('width', x.rangeBand() / (stacked ? 1 : data.length) );
+
             bars
-                .style('fill', function(d,i,j){ return color(d, j, i);  })
-                .style('stroke', function(d,i,j){ return color(d, j, i); })
                 .on('mouseover', function(d,i) { //TODO: figure out why j works above, but not here
                     d3.select(this).classed('hover', true);
                     dispatch.elementMouseover({
@@ -236,9 +236,65 @@ nv.models.multiBar = function() {
                     });
                     d3.event.stopPropagation();
                 });
+
+            if (getXerr(data[0],0)) {
+                barsEnter.append('polyline');
+                bars.select('polyline')
+                    .attr('fill', 'none')
+                    .attr('points', function(d, i){
+                        var xerr = getXerr(d,i)
+                            , mid = 0.8 * x.rangeBand() / ((stacked ? 1 : data.length) * 2);
+                        xerr = xerr.length ? xerr : [-Math.abs(xerr), Math.abs(xerr)];
+                        xerr = xerr.map(function(e) { return y(0) - y(e * -1) });
+                        var a = [[-mid, xerr[0]], [mid, xerr[0]], [0, xerr[0]], [0, xerr[1]], [-mid, xerr[1]], [mid, xerr[1]]];
+                        return a.map(function (path) { return path.join(',') }).join(' ');
+                    })
+                    .attr('transform', function(d,i) {
+                        var mid = x.rangeBand() / ((stacked ? 1 : data.length) * 2);
+                        return 'translate('+mid+','+ ( getY(d,i) < 0 ? y(getY(d,i)) - y(0) : 0 ) +')'
+                    });
+                }
+
+            barsEnter.append('text');
+
+            if (showValues && !stacked) {
+                bars.select('text')
+                    .attr('text-anchor', function(d,i) { return getY(d,i) > 0 ? 'end' : 'start' })
+                    .attr('y', 0 - x.rangeBand() / (data.length * 2))
+                    .attr('dy', '.32em')
+                    .text(function(d,i) {
+                        var t = valueFormat(getY(d,i))
+                            , xerr = getXerr(d,i);
+                        if (xerr === undefined){
+                            return t;
+                        }else{
+                            if (!xerr.length){
+                                return t + '±' + valueFormat(Math.abs(xerr));
+                            }else if (xerr[0] == xerr[1]){
+                                return t + (xerr[0] > 0 ? '+' : '-') + valueFormat(Math.abs(xerr[0]));
+                            }else{
+                                return t + (xerr[1] > 0 ? '+' : '-') + valueFormat(Math.abs(xerr[1])) + (xerr[0] > 0 ? '+' : '-') + valueFormat(Math.abs(xerr[0]));
+                            }
+                        }
+                    });
+                bars.watchTransition(renderWatch, 'multibar')
+                    .select('text')
+                    .attr('x', function(d,i) {
+                        // return getY(d,i) < 0 ? y(getY(d,i)) - y(0) + 4 : 0 - 4
+                        var xerr = getXerr(d,i)
+                        xerr = xerr.length ? xerr : [-Math.abs(xerr), Math.abs(xerr)];
+                        var xerrMax = Math.max.apply(null, xerr);
+                        var xerrMin = Math.min.apply(null, xerr);
+                        return getY(d,i) < 0 ? y(getY(d,i)) - y(0) + (y(xerrMin) - y(0)) + 5 : y(xerrMax) - y(0) - 5
+                    })
+                    .attr('transform', 'rotate(90)')
+            } else {
+                bars.selectAll('text').text('');
+            }
+
+
             bars
                 .attr('class', function(d,i) { return getY(d,i) < 0 ? 'nv-bar negative' : 'nv-bar positive'})
-                .attr('transform', function(d,i) { return 'translate(' + x(getX(d,i)) + ',0)'; })
 
             if (barColor) {
                 if (!disabled) disabled = data.map(function() { return true });
@@ -247,48 +303,31 @@ nv.models.multiBar = function() {
                     .style('stroke', function(d,i,j) { return d3.rgb(barColor(d,i)).darker(  disabled.map(function(d,i) { return i }).filter(function(d,i){ return !disabled[i]  })[j]   ).toString(); });
             }
 
-            var barSelection =
-                bars.watchTransition(renderWatch, 'multibar', Math.min(250, duration))
-                    .delay(function(d,i) {
-                        return i * duration / data[0].values.length;
-                    });
-            if (stacked)
-                barSelection
-                    .attr('y', function(d,i) {
-                        return y((stacked ? d.y1 : 0));
+            if (stacked) {
+                bars.watchTransition(renderWatch, 'multibar')
+                    .attr('transform', function(d,i){
+                        return 'translate(' + x(getX(d,i)) + ','+y(d.y1)+')'
                     })
+                    .select('rect')
+                    .attr('width', x.rangeBand() / (stacked ? 1 : data.length) )
                     .attr('height', function(d,i) {
-                        return Math.max(Math.abs(y(d.y + (stacked ? d.y0 : 0)) - y((stacked ? d.y0 : 0))),1);
+                        return Math.max(Math.abs(y(d.y + d.y0) - y(d.y0)),1);
                     })
-                    .attr('x', function(d,i) {
-                        return stacked ? 0 : (d.series * x.rangeBand() / data.length )
+            }else{
+                bars.watchTransition(renderWatch, 'multibar')
+                    .attr('transform', function(d,i) {
+                        return 'translate(' + (d.series * x.rangeBand() / data.length + x(getX(d,i))) + ','+(getY(d,i) < 0 ? y(0) : y(0) - y(getY(d,i)) < 1 ? y(0) - 1 : y(getY(d,i)) || 0) +')';
                     })
-                    .attr('width', x.rangeBand() / (stacked ? 1 : data.length) );
-            else
-                barSelection
-                    .attr('x', function(d,i) {
-                        return d.series * x.rangeBand() / data.length
-                    })
+                    .select('rect')
                     .attr('width', x.rangeBand() / data.length)
-                    .attr('y', function(d,i) {
-                        return getY(d,i) < 0 ?
-                            y(0) :
-                                y(0) - y(getY(d,i)) < 1 ?
-                            y(0) - 1 :
-                            y(getY(d,i)) || 0;
-                    })
                     .attr('height', function(d,i) {
                         return Math.max(Math.abs(y(getY(d,i)) - y(0)),1) || 0;
-                    });
+                    })
 
+            }
             //store old scales for use in transitions on update
             x0 = x.copy();
             y0 = y.copy();
-
-            // keep track of the last data value length for transition calculations
-            if (data[0] && data[0].values) {
-                last_datalength = data[0].values.length;
-            }
 
         });
 
@@ -311,6 +350,7 @@ nv.models.multiBar = function() {
         height:  {get: function(){return height;}, set: function(_){height=_;}},
         x:       {get: function(){return getX;}, set: function(_){getX=_;}},
         y:       {get: function(){return getY;}, set: function(_){getY=_;}},
+        xErr:    {get: function(){return getXerr;}, set: function(_){getXerr=_;}},
         xScale:  {get: function(){return x;}, set: function(_){x=_;}},
         yScale:  {get: function(){return y;}, set: function(_){y=_;}},
         xDomain: {get: function(){return xDomain;}, set: function(_){xDomain=_;}},
@@ -318,12 +358,15 @@ nv.models.multiBar = function() {
         xRange:  {get: function(){return xRange;}, set: function(_){xRange=_;}},
         yRange:  {get: function(){return yRange;}, set: function(_){yRange=_;}},
         forceY:  {get: function(){return forceY;}, set: function(_){forceY=_;}},
+        showValues: {get: function(){return showValues;}, set: function(_){showValues=_;}},
         stacked: {get: function(){return stacked;}, set: function(_){stacked=_;}},
         stackOffset: {get: function(){return stackOffset;}, set: function(_){stackOffset=_;}},
         clipEdge:    {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         disabled:    {get: function(){return disabled;}, set: function(_){disabled=_;}},
         id:          {get: function(){return id;}, set: function(_){id=_;}},
         hideable:    {get: function(){return hideable;}, set: function(_){hideable=_;}},
+        valueFormat:  {get: function(){return valueFormat;}, set: function(_){valueFormat=_;}},
+        valuePadding: {get: function(){return valuePadding;}, set: function(_){valuePadding=_;}},
         groupSpacing:{get: function(){return groupSpacing;}, set: function(_){groupSpacing=_;}},
 
         // options that require extra logic in the setter
@@ -341,7 +384,7 @@ nv.models.multiBar = function() {
             color = nv.utils.getColor(_);
         }},
         barColor:  {get: function(){return barColor;}, set: function(_){
-            barColor = _ ? nv.utils.getColor(_) : null;
+            barColor = nv.utils.getColor(_);
         }}
     });
 

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -26,10 +26,11 @@ nv.models.multiBarChart = function() {
         , reduceXTicks = true // if false a tick will show for every data point
         , staggerLabels = false
         , rotateLabels = 0
+        , stacked = false
         , tooltips = true
         , tooltip = function(key, x, y, e, graph) {
-            return '<h3>' + key + '</h3>' +
-                '<p>' +  y + ' on ' + x + '</p>'
+            return '<h3>' + key + ' - ' + x + '</h3>' +
+                '<p>' +  y + '</p>'
         }
         , x //can be accessed via chart.xScale()
         , y //can be accessed via chart.yScale()
@@ -42,7 +43,7 @@ nv.models.multiBarChart = function() {
         ;
 
     state.stacked = false // DEPRECATED Maintained for backward compatibility
-    
+
     multibar
         .stacked(false)
     ;
@@ -170,7 +171,9 @@ nv.models.multiBarChart = function() {
             var g = wrap.select('g');
 
             gEnter.append('g').attr('class', 'nv-x nv-axis');
-            gEnter.append('g').attr('class', 'nv-y nv-axis');
+            gEnter.append('g').attr('class', 'nv-y nv-axis')
+                .append('g').attr('class', 'nv-zeroLine')
+                .append('line');
             gEnter.append('g').attr('class', 'nv-barsWrap');
             gEnter.append('g').attr('class', 'nv-legendWrap');
             gEnter.append('g').attr('class', 'nv-controlsWrap');
@@ -226,7 +229,7 @@ nv.models.multiBarChart = function() {
             var barsWrap = g.select('.nv-barsWrap')
                 .datum(data.filter(function(d) { return !d.disabled }));
 
-            barsWrap.call(multibar);
+            barsWrap.transition().call(multibar);
 
             // Setup Axes
             if (showXAxis) {

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -21,9 +21,11 @@ nv.models.multiBarHorizontal = function() {
         , disabled // used in conjunction with barColor to communicate from multiBarHorizontalChart what series are disabled
         , stacked = false
         , showValues = false
-        , showBarLabels = false
-        , valuePadding = 60
+        , clipEdge = true
+        , stackOffset = 'zero' // options include 'silhouette', 'wiggle', 'expand', 'zero', or a custom function
+        , valuePadding = 80
         , groupSpacing = 0.1
+        , hideable = false
         , valueFormat = d3.format(',.2f')
         , delay = 1200
         , xDomain
@@ -49,9 +51,19 @@ nv.models.multiBarHorizontal = function() {
                 container = d3.select(this);
             nv.utils.initSVG(container);
 
+            if(hideable && data.length) hideable = [{
+                values: data[0].values.map(function(d) {
+                        return {
+                            x: d.x,
+                            y: 0,
+                            series: d.series,
+                            size: 0.01
+                        };}
+                )}];
+
             if (stacked)
                 data = d3.layout.stack()
-                    .offset('zero')
+                    .offset(stackOffset)
                     .values(function(d){ return d.values })
                     .y(getY)
                 (data);
@@ -86,19 +98,40 @@ nv.models.multiBarHorizontal = function() {
             var seriesData = (xDomain && yDomain) ? [] : // if we know xDomain and yDomain, no need to calculate
                 data.map(function(d) {
                     return d.values.map(function(d,i) {
-                        return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1 }
+                        return { x: getX(d,i), y: getY(d,i), y0: d.y0, y1: d.y1, yerr: getYerr(d,i) }
                     })
                 });
 
             x.domain(xDomain || d3.merge(seriesData).map(function(d) { return d.x }))
                 .rangeBands(xRange || [0, availableHeight], groupSpacing);
 
-            y.domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) { return stacked ? (d.y > 0 ? d.y1 + d.y : d.y1 ) : d.y }).concat(forceY)))
-
-            if (showValues && !stacked)
-                y.range(yRange || [(y.domain()[0] < 0 ? valuePadding : 0), availableWidth - (y.domain()[1] > 0 ? valuePadding : 0) ]);
-            else
-                y.range(yRange || [0, availableWidth]);
+            y.domain(yDomain || d3.extent(d3.merge(seriesData).map(function(d) {
+                    var yerr = d.yerr.length ? d.yerr : [-Math.abs(d.yerr), Math.abs(d.yerr)];
+                    var yerrMax = Math.max.apply(null, yerr);
+                    var yerrMin = Math.min.apply(null, yerr);
+                    if (stacked){
+                        if (d.y > 0){
+                            return (d.y1 + d.y + (yerrMax > 0 ? yerrMax : 0))
+                        }else{
+                            return (d.y1 + (yerrMin < 0 ? yerrMin : 0))
+                        }
+                    }else{
+                        if (d.y > 0){
+                            return (d.y + (yerrMax > 0 ? yerrMax : 0))
+                        }else{
+                            return (d.y + (yerrMin < 0 ? yerrMin : 0))
+                        }
+                    }
+                }).concat(forceY)))
+            var offsetRight = 0;
+            var offsetLeft = 0;
+            if (showValues && !stacked) {
+                if (y.domain()[0] < 0)
+                    offsetRight += valuePadding
+                if (y.domain()[1] > 0)
+                    offsetLeft += valuePadding
+            }
+            y.range(yRange || [0 + offsetLeft, availableWidth - offsetRight]);
 
             x0 = x0 || x;
             y0 = y0 || d3.scale.linear().domain(y.domain()).range([y(0),y(0)]);
@@ -112,6 +145,15 @@ nv.models.multiBarHorizontal = function() {
 
             gEnter.append('g').attr('class', 'nv-groups');
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+            defsEnter.append('clipPath')
+                .attr('id', 'nv-edge-clip-' + id)
+                .append('rect');
+            wrap.select('#nv-edge-clip-' + id + ' rect')
+                .attr('width', availableWidth)
+                .attr('height', availableHeight);
+
+            g.attr('clip-path', clipEdge ? 'url(#nv-edge-clip-' + id + ')' : '');
 
             var groups = wrap.select('.nv-groups').selectAll('.nv-group')
                 .data(function(d) { return d }, function(d,i) { return i });
@@ -132,7 +174,7 @@ nv.models.multiBarHorizontal = function() {
                 .style('fill-opacity', .75);
 
             var bars = groups.selectAll('g.nv-bar')
-                .data(function(d) { return d.values });
+                .data(function(d) { return (hideable && !data.length) ? hideable.values : d.values });
             bars.exit().remove();
 
             var barsEnter = bars.enter().append('g')
@@ -142,7 +184,7 @@ nv.models.multiBarHorizontal = function() {
 
             barsEnter.append('rect')
                 .attr('width', 0)
-                .attr('height', x.rangeBand() / (stacked ? 1 : data.length) )
+                .attr('height', x.rangeBand() / (stacked ? 1 : data.length) );
 
             bars
                 .on('mouseover', function(d,i) { //TODO: figure out why j works above, but not here
@@ -195,15 +237,14 @@ nv.models.multiBarHorizontal = function() {
 
             if (getYerr(data[0],0)) {
                 barsEnter.append('polyline');
-
                 bars.select('polyline')
                     .attr('fill', 'none')
                     .attr('points', function(d,i) {
-                        var xerr = getYerr(d,i)
+                        var yerr = getYerr(d,i)
                             , mid = 0.8 * x.rangeBand() / ((stacked ? 1 : data.length) * 2);
-                        xerr = xerr.length ? xerr : [-Math.abs(xerr), Math.abs(xerr)];
-                        xerr = xerr.map(function(e) { return y(e) - y(0); });
-                        var a = [[xerr[0],-mid], [xerr[0],mid], [xerr[0],0], [xerr[1],0], [xerr[1],-mid], [xerr[1],mid]];
+                        yerr = yerr.length ? yerr : [-Math.abs(yerr), Math.abs(yerr)];
+                        yerr = yerr.map(function(e) { return y(e) - y(0); });
+                        var a = [[yerr[0],-mid], [yerr[0],mid], [yerr[0],0], [yerr[1],0], [yerr[1],-mid], [yerr[1],mid]];
                         return a.map(function (path) { return path.join(',') }).join(' ');
                     })
                     .attr('transform', function(d,i) {
@@ -222,32 +263,29 @@ nv.models.multiBarHorizontal = function() {
                     .text(function(d,i) {
                         var t = valueFormat(getY(d,i))
                             , yerr = getYerr(d,i);
-                        if (yerr === undefined)
+                        if (yerr === undefined){
                             return t;
-                        if (!yerr.length)
-                            return t + '±' + valueFormat(Math.abs(yerr));
-                        return t + '+' + valueFormat(Math.abs(yerr[1])) + '-' + valueFormat(Math.abs(yerr[0]));
+                        }else{
+                            if (!yerr.length){
+                                return t + '±' + valueFormat(Math.abs(yerr));
+                            }else if (yerr[0] == yerr[1]){
+                                return t + (yerr[0] > 0 ? '+' : '-') + valueFormat(Math.abs(yerr[0]));
+                            }else{
+                                return t + (yerr[1] > 0 ? '+' : '-') + valueFormat(Math.abs(yerr[1])) + (yerr[0] > 0 ? '+' : '-') + valueFormat(Math.abs(yerr[0]));
+                            }
+                        }
                     });
                 bars.watchTransition(renderWatch, 'multibarhorizontal: bars')
                     .select('text')
-                    .attr('x', function(d,i) { return getY(d,i) < 0 ? -4 : y(getY(d,i)) - y(0) + 4 })
+                    .attr('x', function(d,i) {
+                        var yerr = getYerr(d,i)
+                        yerr = yerr.length ? yerr : [-Math.abs(yerr), Math.abs(yerr)];
+                        var yerrMax = Math.max.apply(null, yerr);
+                        var yerrMin = Math.min.apply(null, yerr);
+                        return getY(d,i) < 0 ? y(yerrMin) - y(0) - 5 : y(getY(d,i)) - y(0) + (y(yerrMax) - y(0)) + 5
+                    })
             } else {
                 bars.selectAll('text').text('');
-            }
-
-            if (showBarLabels && !stacked) {
-                barsEnter.append('text').classed('nv-bar-label',true);
-                bars.select('text.nv-bar-label')
-                    .attr('text-anchor', function(d,i) { return getY(d,i) < 0 ? 'start' : 'end' })
-                    .attr('y', x.rangeBand() / (data.length * 2))
-                    .attr('dy', '.32em')
-                    .text(function(d,i) { return getX(d,i) });
-                bars.watchTransition(renderWatch, 'multibarhorizontal: bars')
-                    .select('text.nv-bar-label')
-                    .attr('x', function(d,i) { return getY(d,i) < 0 ? y(0) - y(getY(d,i)) + 4 : -4 });
-            }
-            else {
-                bars.selectAll('text.nv-bar-label').text('');
             }
 
             bars
@@ -266,10 +304,10 @@ nv.models.multiBarHorizontal = function() {
                         return 'translate(' + y(d.y1) + ',' + x(getX(d,i)) + ')'
                     })
                     .select('rect')
+                    .attr('height', x.rangeBand() )
                     .attr('width', function(d,i) {
                         return Math.abs(y(getY(d,i) + d.y0) - y(d.y0))
-                    })
-                    .attr('height', x.rangeBand() );
+                    });
             else
                 bars.watchTransition(renderWatch, 'multibarhorizontal: bars')
                     .attr('transform', function(d,i) {
@@ -320,12 +358,13 @@ nv.models.multiBarHorizontal = function() {
         xRange:  {get: function(){return xRange;}, set: function(_){xRange=_;}},
         yRange:  {get: function(){return yRange;}, set: function(_){yRange=_;}},
         forceY:  {get: function(){return forceY;}, set: function(_){forceY=_;}},
-        stacked: {get: function(){return stacked;}, set: function(_){stacked=_;}},
         showValues: {get: function(){return showValues;}, set: function(_){showValues=_;}},
-        // this shows the group name, seems pointless?
-        //showBarLabels:    {get: function(){return showBarLabels;}, set: function(_){showBarLabels=_;}},
+        stacked: {get: function(){return stacked;}, set: function(_){stacked=_;}},
+        stackOffset: {get: function(){return stackOffset;}, set: function(_){stackOffset=_;}},
+        clipEdge:    {get: function(){return clipEdge;}, set: function(_){clipEdge=_;}},
         disabled:     {get: function(){return disabled;}, set: function(_){disabled=_;}},
         id:           {get: function(){return id;}, set: function(_){id=_;}},
+        hideable:    {get: function(){return hideable;}, set: function(_){hideable=_;}},
         valueFormat:  {get: function(){return valueFormat;}, set: function(_){valueFormat=_;}},
         valuePadding: {get: function(){return valuePadding;}, set: function(_){valuePadding=_;}},
         groupSpacing:{get: function(){return groupSpacing;}, set: function(_){groupSpacing=_;}},

--- a/src/models/multiBarHorizontal.js
+++ b/src/models/multiBarHorizontal.js
@@ -300,8 +300,8 @@ nv.models.multiBarHorizontal = function() {
                             yerr = yerr.length ? yerr : [-Math.abs(yerr), Math.abs(yerr)];
                             var yerrMax = Math.max.apply(null, yerr);
                             var yerrMin = Math.min.apply(null, yerr);
-                            shiftRight = y(yerrMax) - y(0);
-                            shiftLeft = y(yerrMin) - y(0)
+                            shiftRight = (y(yerrMax) - y(0)) > 0 ? y(yerrMax) - y(0) : 0;
+                            shiftLeft = (y(yerrMin) - y(0) < 0 ? y(yerrMin) - y(0) : 0);
                         }
                         return getY(d,i) < 0 ? shiftLeft - 5 : y(getY(d,i)) - y(0) + shiftRight + 5
                     })

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -22,6 +22,10 @@ nv.models.multiBarHorizontalChart = function() {
         , showLegend = true
         , showXAxis = true
         , showYAxis = true
+        , rightAlignYAxis = false
+        , reduceXTicks = true // if false a tick will show for every data point
+        , staggerLabels = false
+        , rotateLabels = 0
         , stacked = false
         , tooltips = true
         , tooltip = function(key, x, y, e, graph) {
@@ -39,7 +43,7 @@ nv.models.multiBarHorizontalChart = function() {
         ;
 
     state.stacked = false; // DEPRECATED Maintained for backward compatibility
-    
+
     multibar
         .stacked(stacked)
     ;

--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -294,6 +294,7 @@ svg.nvd3-svg {
   fill-opacity: 1;
 }
 
+.nvd3 .nv-multibar .nv-groups text,
 .nvd3 .nv-discretebar .nv-groups text,
 .nvd3 .nv-multibarHorizontal .nv-groups text {
   font-weight: bold;


### PR DESCRIPTION
I'm afraid I did lot of refactoring to make both models equal.

Whats new:
* both models now include same set of features
* uses same logic to draw content
* yErr/xErr now display within chart
* show values in combination with yErr/xErr now display value outside of yErr/xErr

What would be nice to fix
* values can be still displayed outside of chart. I guess it's impossible to calculate length of text
* multiBar xAxis is drawn with padding and therefore values are displayed across the text - first screenshot Group A, Group B, etc... I couldn't figure out how to make it stick to the bottom. My guess would be that domain instead of range needs to be changed..

Here are some screens of a chart once you change model from multiBar to multiBarHorizontal
![screen shot 2015-01-18 at 14 20 10](https://cloud.githubusercontent.com/assets/482174/5792529/34974b00-9f1d-11e4-996d-366cfe26871b.png)
![screen shot 2015-01-18 at 14 19 51](https://cloud.githubusercontent.com/assets/482174/5792531/349c361a-9f1d-11e4-9f13-f522a7ed8a56.png)
![screen shot 2015-01-18 at 14 19 58](https://cloud.githubusercontent.com/assets/482174/5792532/349d163e-9f1d-11e4-8487-0cddd6c12088.png)
![screen shot 2015-01-18 at 14 20 19](https://cloud.githubusercontent.com/assets/482174/5792530/34976ba8-9f1d-11e4-99be-b20d0713c1c7.png)

Yeah and sorry for all the commits. Last minute bugs :disappointed: 
