### PR TITLE
Allow for setting of pie chart margins

### DIFF
--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -244,6 +244,12 @@ nv.models.pieChart = function() {
         duration: {get: function(){return duration;}, set: function(_){
             duration = _;
             renderWatch.reset(duration);
+        }},
+        margin: {get: function(){return margin;}, set: function(_){
+            margin.top    = _.top    !== undefined ? _.top    : margin.top;
+            margin.right  = _.right  !== undefined ? _.right  : margin.right;
+            margin.bottom = _.bottom !== undefined ? _.bottom : margin.bottom;
+            margin.left   = _.left   !== undefined ? _.left   : margin.left;
         }}
     });
     nv.utils.inheritOptions(chart, pie);


### PR DESCRIPTION
Margins on pie charts were documented as extensible and commented
as extensible, but in actuality, they were declared locally and never
extended.

This follow the same pattern used in other components in order to
make pie chart margins actually extensible.

Sorry about issuing this against the wrong branch earlier, and thanks for
your graciousness in your response!