### PR TITLE
Change bower.json d3 dependency to support newer versions

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   ],
   "license": "Apache License, v2.0",
   "dependencies": {
-    "d3": "~3.3.13"
+    "d3": "^3.3.13"
   },
   "ignore": [
     "**/.*",
@@ -39,9 +39,9 @@
     "*.md"
   ],
   "resolutions": {
-    "d3": "~3.3.13"
+    "d3": "^3.3.13"
   },
   "devDependencies": {
-    "d3": "~3.3.13"
+    "d3": "^3.3.13"
   }
 }


### PR DESCRIPTION
The code that specifies the d3 version that is to be installed with nvd3 is the following:
```javascript
  "dependencies": {
    "d3": "~3.3.13"
  },
  "resolutions": {
    "d3": "~3.3.13"
  },
  "devDependencies": {
    "d3": "~3.3.13"
  }
```

The 3.3.13 version is the last patch of the 3.3 minor release. This means that "~3.3.13" allows for only the exact 3.3.13 version to be installed. This causes warnings when trying to use d3 with other libraries.

As nvd3 works normally with the newer versions of d3, maybe the version should be changed to "^3.3.13", what will allow the most recent version of d3 to be used, but will disallow the installation of a future 4.0.0 version that may contain breaking changes.