### PR TITLE
Use full scatter chart width for legend if labels are not aligned

### DIFF
--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -195,7 +195,13 @@ nv.models.scatterChart = function() {
 
             // Legend
             if (showLegend) {
-                legend.width( availableWidth / 2 );
+                var xOffset = 0;
+                if (legend.align()) {
+                    legend.width(availableWidth / 2 );
+                    xOffset = availableWidth / 2
+                } else {
+                    legend.width(availableWidth);
+                }
 
                 wrap.select('.nv-legendWrap')
                     .datum(data)
@@ -208,7 +214,7 @@ nv.models.scatterChart = function() {
                 }
 
                 wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(' + (availableWidth / 2) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + xOffset + ',' + (-margin.top) +')');
             }
 
             // Main Chart Component(s)


### PR DESCRIPTION
If the legend labels should not be aligned vertically this patch makes sure that the full width of the chart is used. This will prevent unwanted linebreaks of the labels which might lead to only one label being on the second line. 

See example screenshots.

*New*
![screen1](https://cloud.githubusercontent.com/assets/386914/6021086/34180956-abb3-11e4-9008-025093308324.jpg)

*Old*
![screen2](https://cloud.githubusercontent.com/assets/386914/6021092/47be5b9a-abb3-11e4-861f-a26f7992d4a9.jpg)
