### PR TITLE
 Regression in the tooltip removal code

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -489,12 +489,26 @@
     nv.tooltip.cleanup = function() {
         // Find the tooltips, mark them for removal by this class (so others cleanups won't find it)
         var tooltips = document.querySelectorAll('.nvtooltip');
+        var purging = [];
         if (tooltips) {
             nv.dom.write(function() {
                 for (var i = 0; i < tooltips.length; i++) {
+                    purging.push(tooltips[i]);
+                    tooltips[i].style.transitionDelay = '0 !important';
+                    tooltips[i].style.opacity = 0;
                     tooltips[i].className = 'nvtooltip-pending-removal';
                 }
             });
+
+            setTimeout(function() {
+                nv.dom.write(function() {
+                    while (purging.length) {
+                        var removeMe = purging.pop();
+                        removeMe.parentNode.removeChild(removeMe);
+                    }
+                });
+            }, 500);
+
         }
     };
 })();


### PR DESCRIPTION
Partially regress a change in the removal of tooltips code, because the code responsible for actually deleting them was removed.

For example, look at the examples/scatterChart.html file. If you look at the "test1" div, the tooltip divs stopped being removed after 5cba3b4 (this commit made some wrong changes to the tooltip code when adding fastdom support, as this is the second time I am making a regression because of it), they are only being marked for removal but the code that actually removes them was removed.

Oh, and why does nvd3 marks the tooltips for removal and removes them after 500ms instead of just removing it in the first place?