### PR TITLE
Use full chart width for legend in multi, linesPlusBar and scatter chart

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -228,7 +228,10 @@ nv.models.linePlusBarChart = function() {
             //------------------------------------------------------------
 
             if (showLegend) {
-                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
+                var legendWidth = legend.align() ? availableWidth / 2 : availableWidth;
+                var legendXPosition = legend.align() ? legendWidth : 0;
+
+                legend.width(legendWidth);
 
                 g.select('.nv-legendWrap')
                     .datum(data.map(function(series) {
@@ -245,7 +248,7 @@ nv.models.linePlusBarChart = function() {
                 }
 
                 g.select('.nv-legendWrap')
-                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + legendXPosition + ',' + (-margin.top) +')');
             }
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');

--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -228,7 +228,7 @@ nv.models.linePlusBarChart = function() {
             //------------------------------------------------------------
 
             if (showLegend) {
-                legend.width( availableWidth / 2 );
+                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
 
                 g.select('.nv-legendWrap')
                     .datum(data.map(function(series) {
@@ -245,7 +245,7 @@ nv.models.linePlusBarChart = function() {
                 }
 
                 g.select('.nv-legendWrap')
-                    .attr('transform', 'translate(' + ( availableWidth / 2 ) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
             }
 
             wrap.attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -139,7 +139,7 @@ nv.models.multiChart = function() {
 
             if (showLegend) {
                 legend.color(color_array);
-                legend.width( availableWidth / 2 );
+                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
 
                 g.select('.legendWrap')
                     .datum(data.map(function(series) {
@@ -156,7 +156,7 @@ nv.models.multiChart = function() {
                 }
 
                 g.select('.legendWrap')
-                    .attr('transform', 'translate(' + ( availableWidth / 2 ) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
             }
 
             lines1

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -138,8 +138,11 @@ nv.models.multiChart = function() {
             });
 
             if (showLegend) {
+                var legendWidth = legend.align() ? availableWidth / 2 : availableWidth;
+                var legendXPosition = legend.align() ? legendWidth : 0;
+
+                legend.width(legendWidth);
                 legend.color(color_array);
-                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
 
                 g.select('.legendWrap')
                     .datum(data.map(function(series) {
@@ -156,7 +159,7 @@ nv.models.multiChart = function() {
                 }
 
                 g.select('.legendWrap')
-                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + legendXPosition + ',' + (-margin.top) +')');
             }
 
             lines1

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -195,13 +195,7 @@ nv.models.scatterChart = function() {
 
             // Legend
             if (showLegend) {
-                var xOffset = 0;
-                if (legend.align()) {
-                    legend.width(availableWidth / 2 );
-                    xOffset = availableWidth / 2
-                } else {
-                    legend.width(availableWidth);
-                }
+                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
 
                 wrap.select('.nv-legendWrap')
                     .datum(data)
@@ -214,7 +208,7 @@ nv.models.scatterChart = function() {
                 }
 
                 wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(' + xOffset + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
             }
 
             // Main Chart Component(s)

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -195,7 +195,10 @@ nv.models.scatterChart = function() {
 
             // Legend
             if (showLegend) {
-                legend.width(legend.align() ? availableWidth / 2 : availableWidth);
+                var legendWidth = legend.align() ? availableWidth / 2 : availableWidth;
+                var legendXPosition = legend.align() ? legendWidth : 0;
+
+                legend.width(legendWidth);
 
                 wrap.select('.nv-legendWrap')
                     .datum(data)
@@ -208,7 +211,7 @@ nv.models.scatterChart = function() {
                 }
 
                 wrap.select('.nv-legendWrap')
-                    .attr('transform', 'translate(' + (legend.align() ? availableWidth / 2 : 0) + ',' + (-margin.top) +')');
+                    .attr('transform', 'translate(' + legendXPosition + ',' + (-margin.top) +')');
             }
 
             // Main Chart Component(s)


### PR DESCRIPTION
In case the legend should not be aligned vertically make use of the full chart width to prevent unwanted line breaks in the legend. 

This patch was already implemented for the scatter chart but I saw that the same behavior applied in the linePlusBarChart and multiChart. The code was accordingly adapted and unified at these places.