### PR TITLE
Added option for lines to specify and change the fill opacity if area is true

### DIFF
--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -22,12 +22,24 @@
     </style>
 </head>
 <body class='with-3d-shadow with-transitions'>
-
+<div style="position:absolute; top: 0; left: 0;">
+    <button onclick="randomizeFillOpacity();">Randomize fill opacity</button>
+</div>
 <div id="chart1"></div>
 
 <script>
     // Wrapping in nv.addGraph allows for '0 timeout render', stores rendered charts in nv.graphs, and may do more in the future... it's NOT required
     var chart;
+    var data;
+
+    var randomizeFillOpacity = function() {
+        var rand = Math.random(0,1);
+        for (var i = 0; i < 100; i++) { // modify sine amplitude
+            data[4].values[i].y = Math.sin(i/(5 + rand)) * .4 * rand - .25;
+        }
+        data[4].fillOpacity = rand;
+        chart.update();
+    };
 
     nv.addGraph(function() {
         chart = nv.models.lineChart()
@@ -48,8 +60,10 @@
             .tickFormat(d3.format(',.2f'))
         ;
 
+        data = sinAndCos();
+
         d3.select('#chart1').append('svg')
-            .datum(sinAndCos())
+            .datum(data)
             .call(chart);
 
         nv.utils.windowResize(chart.update);
@@ -59,6 +73,7 @@
 
     function sinAndCos() {
         var sin = [],
+            sin2 = [],
             cos = [],
             rand = [],
             rand2 = []
@@ -66,6 +81,7 @@
 
         for (var i = 0; i < 100; i++) {
             sin.push({x: i, y: i % 10 == 5 ? null : Math.sin(i/10) }); //the nulls are to show how defined works
+            sin2.push({x: i, y: Math.sin(i/5) * 0.4 - 0.25});
             cos.push({x: i, y: .5 * Math.cos(i/10)});
             rand.push({x:i, y: Math.random() / 10});
             rand2.push({x: i, y: Math.cos(i/10) + Math.random() / 10 })
@@ -87,12 +103,18 @@
                 values: rand,
                 key: "Random Points",
                 color: "#2222ff"
-            }
-            ,
+            },
             {
                 values: rand2,
                 key: "Random Cosine",
                 color: "#667711"
+            },
+            {
+                area: true,
+                values: sin2,
+                key: "Fill opacity",
+                color: "#EF9CFB",
+                fillOpacity: .1
             }
         ];
     }

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -105,7 +105,7 @@ nv.models.line = function() {
                 .style('stroke', function(d,i){ return color(d, i)});
             groups.watchTransition(renderWatch, 'line: groups')
                 .style('stroke-opacity', 1)
-                .style('fill-opacity', .5);
+                .style('fill-opacity', function(d) { return d.fillOpacity ? d.fillOpacity : .5});
 
             var areaPaths = groups.selectAll('path.nv-area')
                 .data(function(d) { return isArea(d) ? [d] : [] }); // this is done differently than lines because I need to check if series is an area

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -105,7 +105,7 @@ nv.models.line = function() {
                 .style('stroke', function(d,i){ return color(d, i)});
             groups.watchTransition(renderWatch, 'line: groups')
                 .style('stroke-opacity', 1)
-                .style('fill-opacity', function(d) { return d.fillOpacity ? d.fillOpacity : .5});
+                .style('fill-opacity', function(d) { return d.fillOpacity || .5});
 
             var areaPaths = groups.selectAll('path.nv-area')
                 .data(function(d) { return isArea(d) ? [d] : [] }); // this is done differently than lines because I need to check if series is an area


### PR DESCRIPTION
This patch allows the user to specify the opacity value beneath a line for a data set. The default value is 0.5. See the example lineChart.html which contains a new curve where the opacity can be randomized on the fly by clicking a button.