### PR TITLE
Make sure lines are drawn as areas in case the area element is set

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -462,6 +462,7 @@ nv.models.linePlusBarChart = function() {
                         dataLines
                             .map(function(d,i) {
                                 return {
+                                    area: d.area,
                                     key: d.key,
                                     values: d.values.filter(function(d,i) {
                                         return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];


### PR DESCRIPTION
This fixes a small bug which prevented the lines in an linePlusBar chart to be drawn as an area. In conjunction with the legend and the fillOpacity feature this can be used e.g. to fill the line in case the bars of this chart are disabled and "unfill" the line again if the user enables the bars again via the legend.