### PR TITLE
Handover fillOpacity for lines in linePlusBar charts

### DIFF
--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -463,6 +463,7 @@ nv.models.linePlusBarChart = function() {
                             .map(function(d,i) {
                                 return {
                                     area: d.area,
+                                    fillOpacity: d.fillOpacity,
                                     key: d.key,
                                     values: d.values.filter(function(d,i) {
                                         return lines.x()(d,i) >= extent[0] && lines.x()(d,i) <= extent[1];


### PR DESCRIPTION
Adds the fillOpacity to the lines for the linePlusBar charts. Otherwise the area will be always drawn with the default opacity of 0.5