### PR TITLE
Added ability to specify line width

### DIFF
--- a/examples/line.html
+++ b/examples/line.html
@@ -89,7 +89,8 @@
             {
                 values: cos,
                 key: "Cosine Wave",
-                color: "#2ca02c"
+                color: "#2ca02c",
+                width: 3
             }
         ];
     }

--- a/examples/line.html
+++ b/examples/line.html
@@ -90,7 +90,7 @@
                 values: cos,
                 key: "Cosine Wave",
                 color: "#2ca02c",
-                width: 3
+                strokeWidth: 3
             }
         ];
     }

--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -93,7 +93,7 @@
                 values: sin,
                 key: "Sine Wave",
                 color: "#ff7f0e",
-                width: 4
+                strokeWidth: 4
             },
             {
                 values: cos,
@@ -109,7 +109,7 @@
                 values: rand2,
                 key: "Random Cosine",
                 color: "#667711",
-                width: 3.5
+                strokeWidth: 3.5
             },
             {
                 area: true,

--- a/examples/lineChart.html
+++ b/examples/lineChart.html
@@ -92,7 +92,8 @@
                 area: true,
                 values: sin,
                 key: "Sine Wave",
-                color: "#ff7f0e"
+                color: "#ff7f0e",
+                width: 4
             },
             {
                 values: cos,
@@ -107,7 +108,8 @@
             {
                 values: rand2,
                 key: "Random Cosine",
-                color: "#667711"
+                color: "#667711",
+                width: 3.5
             },
             {
                 area: true,

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -95,7 +95,7 @@ nv.models.line = function() {
                 .data(function(d) { return d }, function(d) { return d.key });
             groups.enter().append('g')
                 .style('stroke-opacity', 1e-6)
-                .style('stroke-width', function(d) { return d.width || strokeWidth })
+                .style('stroke-width', function(d) { return d.strokeWidth || strokeWidth })
                 .style('fill-opacity', 1e-6);
 
             groups.exit().remove();

--- a/src/models/line.js
+++ b/src/models/line.js
@@ -11,6 +11,7 @@ nv.models.line = function() {
     var margin = {top: 0, right: 0, bottom: 0, left: 0}
         , width = 960
         , height = 500
+        , strokeWidth = 1.5
         , color = nv.utils.defaultColor() // a function that returns a color
         , getX = function(d) { return d.x } // accessor to get the x value from a data point
         , getY = function(d) { return d.y } // accessor to get the y value from a data point
@@ -94,6 +95,7 @@ nv.models.line = function() {
                 .data(function(d) { return d }, function(d) { return d.key });
             groups.enter().append('g')
                 .style('stroke-opacity', 1e-6)
+                .style('stroke-width', function(d) { return d.width || strokeWidth })
                 .style('fill-opacity', 1e-6);
 
             groups.exit().remove();
@@ -138,6 +140,7 @@ nv.models.line = function() {
 
             var linePaths = groups.selectAll('path.nv-line')
                 .data(function(d) { return [d.values] });
+
             linePaths.enter().append('path')
                 .attr('class', 'nv-line')
                 .attr('d',

--- a/src/nv.d3.css
+++ b/src/nv.d3.css
@@ -346,20 +346,10 @@ svg.nvd3-svg {
 
 .nvd3 .nv-groups path.nv-line {
   fill: none;
-  stroke-width: 1.5px;
 }
-
-.nvd3 .nv-groups path.nv-line.nv-thin-line {
-  stroke-width: 1px;
-}
-
 
 .nvd3 .nv-groups path.nv-area {
   stroke: none;
-}
-
-.nvd3 .nv-line.hover path {
-  stroke-width: 6px;
 }
 
 .nvd3.nv-line .nvd3.nv-scatter .nv-groups .nv-point {


### PR DESCRIPTION
Sometimes it is nice to be able to have lines of different width. To use this feature you just need to add a width property, as I've done in the example files. I had to remove the stroke-width style from the nv-line rule and added some logic to line.js to choose 1.5 as default unless the width property exists. I also removed the nv-line.hover rule because it wasn't being used anywhere and was modifying stroke-width.