### PR TITLE
Remove tooltip offset adjustment in multiBarChart and multiBarChartHorizontal

### DIFF
--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -68,8 +68,8 @@ nv.models.multiBarChart = function() {
     var stacked = false;
 
     var showTooltip = function(e, offsetElement) {
-        var left = e.pos[0] + ( offsetElement.offsetLeft || 0 ),
-            top = e.pos[1] + ( offsetElement.offsetTop || 0),
+        var left = e.pos[0],
+            top = e.pos[1],
             x = xAxis.tickFormat()(multibar.x()(e.point, e.pointIndex)),
             y = yAxis.tickFormat()(multibar.y()(e.point, e.pointIndex)),
             content = tooltip(e.series.key, x, y, e, chart);

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -62,8 +62,8 @@ nv.models.multiBarHorizontalChart = function() {
     //------------------------------------------------------------
 
     var showTooltip = function(e, offsetElement) {
-        var left = e.pos[0] + ( offsetElement.offsetLeft || 0 ),
-            top = e.pos[1] + ( offsetElement.offsetTop || 0),
+        var left = e.pos[0],
+            top = e.pos[1],
             x = xAxis.tickFormat()(multibar.x()(e.point, e.pointIndex)),
             y = yAxis.tickFormat()(multibar.y()(e.point, e.pointIndex)),
             content = tooltip(e.series.key, x, y, e, chart);


### PR DESCRIPTION

This offsetting results in misaligned tooltips when the svg element is within a div.
I believe this is due to the tooltip's positioning being 'absolute' within it's container, not 'fixed' to the viewport, making the offset calculation unnecessary.