### PR TITLE
Clear chart on no data #2

### DIFF
--- a/src/models/bulletChart.js
+++ b/src/models/bulletChart.js
@@ -57,6 +57,9 @@ nv.models.bulletChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!d || !ranges.call(this, d, i)) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/cumulativeLineChart.js
+++ b/src/models/cumulativeLineChart.js
@@ -169,6 +169,9 @@ nv.models.cumulativeLineChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/discreteBarChart.js
+++ b/src/models/discreteBarChart.js
@@ -81,6 +81,9 @@ nv.models.discreteBarChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/historicalBarChart.js
+++ b/src/models/historicalBarChart.js
@@ -108,6 +108,9 @@ nv.models.historicalBarChart = function(bar_model) {
 
             // Display noData message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -121,6 +121,10 @@ nv.models.lineChart = function() {
 
             // Display noData message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/linePlusBarChart.js
+++ b/src/models/linePlusBarChart.js
@@ -149,6 +149,9 @@ nv.models.linePlusBarChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/lineWithFocusChart.js
+++ b/src/models/lineWithFocusChart.js
@@ -126,6 +126,9 @@ nv.models.lineWithFocusChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/multiBarChart.js
+++ b/src/models/multiBarChart.js
@@ -143,6 +143,9 @@ nv.models.multiBarChart = function() {
 
             // Display noData message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/multiBarHorizontalChart.js
+++ b/src/models/multiBarHorizontalChart.js
@@ -134,6 +134,9 @@ nv.models.multiBarHorizontalChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/multiChart.js
+++ b/src/models/multiChart.js
@@ -83,6 +83,9 @@ nv.models.multiChart = function() {
 
             // Display noData message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/pieChart.js
+++ b/src/models/pieChart.js
@@ -103,6 +103,9 @@ nv.models.pieChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/scatterChart.js
+++ b/src/models/scatterChart.js
@@ -147,6 +147,9 @@ nv.models.scatterChart = function() {
 
             // Display noData message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/sparklinePlus.js
+++ b/src/models/sparklinePlus.js
@@ -38,6 +38,9 @@ nv.models.sparklinePlus = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/src/models/stackedAreaChart.js
+++ b/src/models/stackedAreaChart.js
@@ -125,6 +125,9 @@ nv.models.stackedAreaChart = function() {
 
             // Display No Data message if there's nothing to show.
             if (!data || !data.length || !data.filter(function(d) { return d.values.length }).length) {
+                //Remove any previously created chart components
+                container.selectAll('g').remove()
+                
                 var noDataText = container.selectAll('.nv-noData').data([noData]);
 
                 noDataText.enter().append('text')

--- a/test/mocha/bullet.coffee
+++ b/test/mocha/bullet.coffee
@@ -139,6 +139,15 @@ describe 'NVD3', ->
             builder.build options, {}
             builder.svg.textContent.should.be.equal 'No Data Available'
 
+
+          it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.bulletChart()
+            builder.buildover options, sampleData, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
+
           it 'margin', ->
             options =
               margin:

--- a/test/mocha/cumulative-line.coffee
+++ b/test/mocha/cumulative-line.coffee
@@ -78,6 +78,13 @@ describe 'NVD3', ->
           cumulativeLine = builder1.$ 'g.nvd3.nv-cumulativeLine'
           cumulativeLine[0].getAttribute('transform').should.be.equal "translate(40,30)"
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.cumulativeLineChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-interactive'

--- a/test/mocha/discretebar.coffee
+++ b/test/mocha/discretebar.coffee
@@ -46,6 +46,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-discreteBarWithAxes'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.discreteBarChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-x.nv-axis'

--- a/test/mocha/historical-bar.coffee
+++ b/test/mocha/historical-bar.coffee
@@ -45,6 +45,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-historicalBarChart'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.historicalBarChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-x.nv-axis'

--- a/test/mocha/line.coffee
+++ b/test/mocha/line.coffee
@@ -86,6 +86,14 @@ describe 'NVD3', ->
             noData = builder.$ '.nv-noData'
             noData[0].textContent.should.equal 'No Data Available'
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.lineChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
+
         it 'interactive tooltip', ->
             builder = new ChartBuilder nv.models.lineChart()
             builder.build options, sampleData2

--- a/test/mocha/multibar-horizontal.coffee
+++ b/test/mocha/multibar-horizontal.coffee
@@ -63,6 +63,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-multiBarHorizontalChart'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.multiBarHorizontalChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-x.nv-axis'

--- a/test/mocha/multibar.coffee
+++ b/test/mocha/multibar.coffee
@@ -66,6 +66,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-multiBarWithLegend'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.multiBarChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-x.nv-axis'

--- a/test/mocha/pie.coffee
+++ b/test/mocha/pie.coffee
@@ -65,6 +65,13 @@ describe 'NVD3', ->
                   it "label '#{item.label}'", ->
                     item.label.should.be.equal labels[i].textContent
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.pieChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-pieWrap'

--- a/test/mocha/scatter.coffee
+++ b/test/mocha/scatter.coffee
@@ -75,6 +75,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-scatterChart'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.scatterChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-background'

--- a/test/mocha/sparkline.coffee
+++ b/test/mocha/sparkline.coffee
@@ -37,9 +37,18 @@ describe 'NVD3', ->
             for opt of options
                 should.exist builder.model[opt](), "#{opt} can be called"
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.sparklinePlus()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'renders', ->
             wrap = builder.$ 'g.nvd3.nv-sparklineplus'
             should.exist wrap[0]
+
+
 
         it 'has correct structure', ->
           cssClasses = [

--- a/test/mocha/stacked.coffee
+++ b/test/mocha/stacked.coffee
@@ -68,6 +68,13 @@ describe 'NVD3', ->
             wrap = builder.$ 'g.nvd3.nv-stackedAreaChart'
             should.exist wrap[0]
 
+        it 'clears chart objects for no data', ->
+            builder = new ChartBuilder nv.models.stackedAreaChart()
+            builder.buildover options, sampleData1, []
+            
+            groups = builder.$ 'g'
+            groups.length.should.equal 0, 'removes chart components'
+
         it 'has correct structure', ->
           cssClasses = [
             '.nv-x.nv-axis'

--- a/test/mocha/test-utils.coffee
+++ b/test/mocha/test-utils.coffee
@@ -25,6 +25,35 @@ class ChartBuilder
         .datum(data)
         .call(@model)
 
+    ###
+    options: an object hash of chart options.
+    data: sample data to pass in to initial chart render chart
+    data2: sample data to pass to second chart render
+
+    This method builds a chart, puts it on the <body> element, and then rebuilds using the second set of data
+    Useful for testing the results of transitioning and the 'noData' state after a chart has had data
+    ###
+    buildover: (options, data, data2)->
+        @svg = document.createElement 'svg'
+        document.querySelector('body').appendChild @svg
+
+        for opt, val of options
+            unless @model[opt]?
+                console.warn "#{opt} not property of model."
+            else
+                @model[opt](val)
+
+        #Set initial data
+        chart = d3.select(@svg)
+        chart.datum(data)
+            .call(@model)
+
+        #Reset the data
+        chart.datum(data2)
+            .call(@model)
+
+
+
     # Removes chart from <body> element.
     teardown: ->
         if @svg?


### PR DESCRIPTION
Refs #2

Currently, when charts are rendered with no data, the 'noData' text is applied, but any previously rendered chart components (legend, controls, any data elements) are left in the SVG.

This patch alter the 'no data' rendering so that the chart structure matches what it would be if it was initially rendered without any data: no legend, no controls, no anything.

The fix largely relies on the fact that nvd3 puts all chart components in in `<g>` elements, such that when the 'no data' state is encountered, removing all created elements should be as simple as finding all `<g>` elements within the container and removing them.

Edit: I was sorely tempted to do some refactoring/extraction of the 'no data' logic from the charts, since it seems that is the same everywhere with the exception of a little variance in the test for 'no data'. Wasn't sure what the policy on this was, or where would be the best place to put the extracted utility (nv.utils perhaps?)