### PR TITLE
Fixed DOM iteration when calculating the totalTooltipOffset

### DIFF
--- a/src/tooltip.js
+++ b/src/tooltip.js
@@ -382,7 +382,8 @@
             if( !isNaN( Elem.offsetTop ) ) {
                 offsetTop += (Elem.offsetTop);
             }
-        } while( Elem === Elem.offsetParent );
+            Elem = Elem.offsetParent;
+        } while( Elem );
         return offsetTop;
     };
 
@@ -395,7 +396,8 @@
             if( !isNaN( Elem.offsetLeft ) ) {
                 offsetLeft += (Elem.offsetLeft);
             }
-        } while( Elem === Elem.offsetParent );
+            Elem = Elem.offsetParent;
+        } while( Elem );
         return offsetLeft;
     };
 


### PR DESCRIPTION
This fixes an issue which leads to a misplacement of the tooltip in case it is nearby the right or top window border. To make it clear that we are iterating the DOM I decided to put the assignment of the parent node into the loop and check for the element instead of doing it inside the while condition (as it was before).