### PR TITLE
fix sourcemaps so they refer to the original source

### DIFF
--- a/GruntFile.js
+++ b/GruntFile.js
@@ -21,7 +21,10 @@ module.exports = function(grunt) {
                     separator: '',
                     banner: '/* nvd3 version ' + _pkg.version + ' (' + _pkg.url + ') ' +
                         '<%= grunt.template.today("yyyy-mm-dd") %> */\n' + '(function(){\n',
-                    footer: '\nnv.version = "' + _pkg.version + '";\n})();'
+                    footer: '\nnv.version = "' + _pkg.version + '";\n})();',
+                    sourceMap: true,
+                    sourceMapName: 'build/nv.d3.js.map',
+                    sourceMapStyle: 'embed'
                 },
                 src: [
                     'src/core.js',
@@ -39,6 +42,8 @@ module.exports = function(grunt) {
         uglify: {
             options: {
                 sourceMap: true,
+                sourceMapIncludeSources : true,
+                sourceMapIn : 'build/nv.d3.js.map',
                 banner: '/* nvd3 version ' + _pkg.version + ' (' + _pkg.url + ') ' +
                     '<%= grunt.template.today("yyyy-mm-dd") %> */\n'
             },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "grunt": "^0.4.5",
-    "grunt-contrib-concat": "~0.2.0",
+    "grunt-contrib-concat": "~1.0.1",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "~0.13.0",
     "grunt-contrib-jshint": "^0.11.0",


### PR DESCRIPTION
Make it possible to debug with the original source files rather than the concatted file.  

Necessary to update grunt-contrib-concat for this feature.

    npm install