### PR TITLE
disable focus dynamically, won't hide

### DIFF
--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -249,6 +249,9 @@ nv.models.lineChart = function() {
             //============================================================
             // Update Focus
             //============================================================
+            
+            g.select('.nv-focusWrap').style('display', focusEnable ? 'initial' : 'none');
+            
             if(!focusEnable) {
                 linesWrap.call(lines);
                 updateXAxis();

--- a/src/models/lineChart.js
+++ b/src/models/lineChart.js
@@ -252,11 +252,11 @@ nv.models.lineChart = function() {
             
             g.select('.nv-focusWrap').style('display', focusEnable ? 'initial' : 'none');
             
-            if(!focusEnable) {
+          /*  if(!focusEnable) {
                 linesWrap.call(lines);
                 updateXAxis();
                 updateYAxis();
-            } else {
+            } else { */
                 focus.width(availableWidth);
                 g.select('.nv-focusWrap')
                     .attr('transform', 'translate(0,' + ( availableHeight + margin.bottom + focus.margin().top) + ')')
@@ -266,7 +266,7 @@ nv.models.lineChart = function() {
                 if(extent !== null){
                     onBrush(extent);
                 }
-            }
+           // }
             //============================================================
             // Event Handling/Dispatching (in chart's scope)
             //------------------------------------------------------------


### PR DESCRIPTION
if chart call  `chart.focusEnable(true); chart.update();` then call  `chart.focusEnable(false);chart.update();`
Focus still visible. in line 253 `g.select('.nv-focusWrap').style('display', focusEnable ? 'initial' : 'none');` solving the problem. Similar approach is in linePlusBarChart.js